### PR TITLE
Fix and enforce documentation and adapt CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,8 @@ jobs:
         run: cargo fmt --all --check
       - name: Ensure that clippy is happy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Verify that documentation contains no invalid links
+        run: cargo doc --workspace --no-deps
       - name: Compile
         run: cargo build --locked
       - name: Run all tests and see that there are no regressions

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ Further traits that are of importance are
 
 ### Profiling while Benchmarking
 We can profile the benchmark code with `cargo bench --bench forc_paper -- --profile-time 20` where `20` is the time for which the benchmarks will be run. A flamegraph will be generated and placed in `target/criterion/forc_paper/profile/flamegraph.csv`.
+
+
+### Development
+To ensure code quality, the `main` branch should only be modified via pull requests.
+The CI is configured that any pull request will run through a set of checks and tests.
+Specifically, the formatting is tested, then clippy is run and finally all tests will be run.
+To avoid unnecessary runs of the CI, these steps can be run locally before every commit.
+This can be done through the `check` script included in the base of the repository.

--- a/automata-learning/Cargo.toml
+++ b/automata-learning/Cargo.toml
@@ -17,9 +17,6 @@ paste = "1.0"
 fixedbitset = "0.4.2"
 test-log = { version = "0.2.14", features = ["trace"] }
 bimap = "0.6.3"
-ouroboros = "0.18.2"
-
-# ouroboros = "0.18.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/automata-learning/src/active/lstar.rs
+++ b/automata-learning/src/active/lstar.rs
@@ -468,7 +468,7 @@ mod tests {
     fn lstar_word_len_mod_k() {
         let alphabet = Simple::from_iter(vec!['a', 'b']);
 
-        for k in (50..=100) {
+        for k in (3..10) {
             let time_start = std::time::Instant::now();
             let oracle = WordLenModk(alphabet.clone(), k);
             let mut lstar = super::LStar::for_moore(alphabet.clone(), oracle);

--- a/automata-learning/src/passive/mod.rs
+++ b/automata-learning/src/passive/mod.rs
@@ -59,7 +59,7 @@ pub fn dba_rpni<A: Alphabet>(sample: &OmegaSample<A, bool>) -> DBA<A> {
     todo!()
 }
 
-/// Takes a reference to an [`InfiniteSample`], which classifies infinite words over the alphabet `A`
+/// Takes a reference to an [`OmegaSample`], which classifies infinite words over the alphabet `A`
 /// with boolean values and infers a [`PreciseDPA`] from it. The steps for this are roughly
 /// - infer the leading prefix (aka Myhill/Nerode) congruence
 /// - produce a [`SplitOmegaSample`] such that each suffix of a sample word which "starts" in a class `c`

--- a/automata-learning/src/passive/precise.rs
+++ b/automata-learning/src/passive/precise.rs
@@ -171,7 +171,7 @@ impl<const N: usize> PState<N> {
 }
 
 /// The precise DPA is a construction for going from a specifically colored FORC to a deterministic
-/// parity automaton. It is described (https://arxiv.org/pdf/2302.11043.pdf)[here, below Lemma 15].
+/// parity automaton. It is described <https://arxiv.org/pdf/2302.11043.pdf>[here, below Lemma 15].
 #[derive(Clone)]
 pub struct PreciseDPA<A: Alphabet, const N: usize = 8> {
     states: Vec<PState<N>>,
@@ -283,7 +283,7 @@ impl<A: Alphabet, const N: usize> TransitionSystem for PreciseDPA<A, N> {
 
     type EdgeColor = usize;
 
-    type TransitionRef<'this> = PreciseDPATransition<'this, A, N>
+    type EdgeRef<'this> = PreciseDPATransition<'this, A, N>
     where
         Self: 'this;
 
@@ -323,7 +323,7 @@ impl<A: Alphabet, const N: usize> Deterministic for PreciseDPA<A, N> {
         &self,
         state: Idx,
         symbol: automata::prelude::SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         let q = state.to_index(self)?;
         let (i, p) = self.take_precise_transition(&q, symbol);
         Some(PreciseDPATransition::new(
@@ -502,7 +502,7 @@ impl<A: Alphabet, const N: usize> Dottable for PreciseDPA<A, N> {
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = automata::ts::dot::DotTransitionAttribute> {
         [DotTransitionAttribute::Label(format!(
             "{}|{}",

--- a/automata-learning/src/passive/sample/omega.rs
+++ b/automata-learning/src/passive/sample/omega.rs
@@ -243,8 +243,7 @@ impl<A: Alphabet> PeriodicOmegaSample<A> {
 }
 
 impl<A: Alphabet, C: Color> OmegaSample<A, C> {
-    /// Create a new sample of infinite words. The alphabet is given as something which implements [`RawSymbols`]. The words
-    /// in the sample are given as an iterator yielding (word, color) pairs.
+    /// Create a new sample of infinite words. The words in the sample are given as an iterator yielding (word, color) pairs.
     pub fn new_omega<W: Into<Reduced<A::Symbol>>, J: IntoIterator<Item = (W, C)>>(
         alphabet: A,
         words: J,

--- a/automata-learning/src/prefixtree.rs
+++ b/automata-learning/src/prefixtree.rs
@@ -102,7 +102,10 @@ mod tests {
         let lead_to_sink = ["ba", "bbbbbbbbba", "ababababbbabaababa", "aaaaaaaaaaaaab"];
         for w in &lead_to_sink {
             for v in &lead_to_sink {
-                assert_eq!(completed.reached(w), completed.reached(v));
+                assert_eq!(
+                    completed.reached_state_index(w),
+                    completed.reached_state_index(v)
+                );
             }
         }
     }

--- a/automata/benches/iai.rs
+++ b/automata/benches/iai.rs
@@ -117,6 +117,7 @@ fn iai_automata_transformations_old() {
     automata_transformations_old(iai::black_box(&DATA.0))
 }
 
+#[allow(deprecated)]
 fn automata_transformations(automata: &[MooreMachine<Simple, usize>]) {
     for automaton in automata {
         let _ts: automata::ts::BTS<_, _, _> = automaton

--- a/automata/src/algorithms/mod.rs
+++ b/automata/src/algorithms/mod.rs
@@ -3,4 +3,7 @@ use std::fmt::Debug;
 use crate::{prelude::*, ts::Quotient};
 
 mod partition_refinement;
-pub use partition_refinement::{mealy_partition_refinement, moore_partition_refinement};
+pub use partition_refinement::{
+    mealy_greatest_bisimulation, mealy_partition_refinement, moore_greatest_bisimulation,
+    moore_partition_refinement,
+};

--- a/automata/src/alphabet.rs
+++ b/automata/src/alphabet.rs
@@ -13,13 +13,14 @@ use crate::{word::FiniteWord, Map, Show};
 /// A symbol of an alphabet, which is also the type of the symbols in a word. We consider different types
 /// of alphabets:
 /// - [`Simple`] alphabets, which are just a set of symbols.
-/// - [`Propositional`] alphabets, where a symbol is a valuation of all propositional variables.
+/// - Propositional alphabets, where a symbol is a valuation of all propositional variables. This is for example
+/// implemented in the `hoars` crate.
 pub trait Symbol: PartialEq + Eq + Debug + Copy + Ord + PartialOrd + Hash + Show {}
 impl<S: PartialEq + Eq + Debug + Copy + Ord + PartialOrd + Hash + Show> Symbol for S {}
 
 /// An expression is used to label edges of a [`crate::ts::TransitionSystem`]. For [`Simple`]
-/// alphabets, an expression is simply a single symbol, whereas for a [`Propositional`] alphabet, an expression
-/// is a propositional formula over the atomic propositions. See [`Propositional`] for more details.
+/// alphabets, an expression is simply a single symbol, whereas for a propositional alphabet, an expression
+/// is a propositional formula over the atomic propositions. See propositional for more details.
 pub trait Expression<S: Symbol>: Hash + Clone + Debug + Eq + Ord + Show {
     /// Type of iterator over the concrete symbols matched by this expression.
     type SymbolsIter<'this>: Iterator<Item = S>
@@ -29,8 +30,8 @@ pub trait Expression<S: Symbol>: Hash + Clone + Debug + Eq + Ord + Show {
     fn symbols(&self) -> Self::SymbolsIter<'_>;
 
     /// Checks whether the given [`Symbol`] matches the expression `self`. For [`Simple`] alphabets, this just
-    /// means that the expression equals the given symbol. For a [`Propositional`] alphabet, this means that
-    /// the expression is satisfied by the given symbol, an example of this is illustrated in [`Propositional`].
+    /// means that the expression equals the given symbol. For a propositional alphabet, this means that
+    /// the expression is satisfied by the given symbol, an example of this is illustrated in propositional.
     fn matches(&self, symbol: S) -> bool;
 
     /// Apply the given function `f` to each symbol matched by this expression.
@@ -66,22 +67,22 @@ pub trait Alphabet: Clone {
         sym: Self::Symbol,
     ) -> Option<(&Self::Expression, &X)>;
 
-    /// Type for an iterator over all possible symbols in the alphabet. For [`Propositional`] alphabets,
+    /// Type for an iterator over all possible symbols in the alphabet. For propositional alphabets,
     /// this may return quite a few symbols (exponential in the number of atomic propositions).
     type Universe<'this>: Iterator<Item = Self::Symbol>
     where
         Self: 'this;
 
     /// Returns an iterator over all possible symbols in the alphabet. May return a huge number of symbols
-    /// if the alphabet is [`Propositional`].
+    /// if the alphabet is propositional.
     fn universe(&self) -> Self::Universe<'_>;
 
     /// Returns true if the given symbol is present in the alphabet.
     fn contains(&self, symbol: Self::Symbol) -> bool;
 
     /// Checks whether the given expression matches the given symbol. For [`Simple`] alphabets, this just
-    /// means that the expression equals the given symbol. For a [`Propositional`] alphabet, this means that
-    /// the expression is satisfied by the given symbol, an example of this is illustrated in [`Propositional`].
+    /// means that the expression equals the given symbol. For a propositional alphabet, this means that
+    /// the expression is satisfied by the given symbol, an example of this is illustrated in propositional.
     fn matches(&self, expression: &Self::Expression, symbol: Self::Symbol) -> bool;
 
     /// Creates an expression from a single symbol.

--- a/automata/src/automaton/acceptor.rs
+++ b/automata/src/automaton/acceptor.rs
@@ -6,7 +6,19 @@ use crate::{
 
 use super::{DFALike, IntoDFA, IntoMealyMachine, IntoMooreMachine, MealyLike, MooreLike};
 
+/// Implementors of this trait transform finite inputs into some other type. For example,
+/// a DFA maps each finite word over its input alphabet to a boolean value, indicating
+/// whether the word is accepted or not. More generally, a Moore machine maps each finite
+/// word over its input alphabet to a state color, and a Mealy machine maps each finite
+/// word over its input alphabet to an edge color. Note that for Mealy machines, this produces
+/// undefined behaviour for empty words.
+///
+/// This has a counterpart for infinite/omega words, see [`OmegaWordTransformer`].
 pub trait FiniteWordTransformer<S, C> {
+    /// Takes a finite `word` over `S` and returns a value of type `C`. Usually, this is used in
+    /// the context of a DFA/Moore machine over an alphabet with symbols `S`. Then, `word` is
+    /// mapped to a boolean value/colour of the state that the automaton ends up in after reading
+    /// `word`.
     fn transform_finite<W: FiniteWord<S>>(&self, word: W) -> C;
 }
 
@@ -28,14 +40,29 @@ impl<D: DFALike> FiniteWordTransformer<SymbolOf<D>, bool> for IntoDFA<D> {
     }
 }
 
+/// A finite word acceptor can classify each finite word consisting of symbols of type `S` as
+/// accepted or rejected. The canonical example for this would be DFAs, which accept a word
+/// if and only if it ends up in an accepting state after reading the word.
 pub trait FiniteWordAcceptor<S> {
+    /// Returns true if and only if the finite `word` consisting of symbols of type `S` is
+    /// accepted by `self`. Prototypical example would be DFAs, which accept a word if and
+    /// only if they end up in an accepting state after reading the word.
     fn accepts_finite<W: FiniteWord<S>>(&self, word: W) -> bool;
 }
 
+/// An omega word transformer can transform each omega word consisting of symbols of type `S`
+/// into some other type `C`. This is the counterpart to [`FiniteWordTransformer`] but for
+/// infinite words.
 pub trait OmegaWordTransformer<S, C> {
+    /// Transforms a given infinite word consisting of symbols of type `S` into a value of type
+    /// `C`.
     fn transform_omega<W: OmegaWord<S>>(&self, word: W) -> C;
 }
 
+/// Classifies each omega word consisting of symbols of type `S` as accepted or rejected. The
+/// counterpart to [`FiniteWordAcceptor`] but for infinite words.
 pub trait OmegaWordAcceptor<S> {
+    /// Returns true if and only if the given infinite word consisting of symbols of type `S`
+    /// is accepted by `self`.
     fn accepts_omega<W: OmegaWord<S>>(&self, word: W) -> bool;
 }

--- a/automata/src/automaton/dba.rs
+++ b/automata/src/automaton/dba.rs
@@ -4,7 +4,7 @@ use super::acceptor::OmegaWordAcceptor;
 
 impl_mealy_automaton!(DBA, bool);
 
-/// Similar to [`IsDfa`], this trait is supposed to be (automatically) implemented by everything that can be viewed
+/// Similar to [`DFALike`], this trait is supposed to be (automatically) implemented by everything that can be viewed
 /// as a [`crate::DBA`].
 pub trait DBALike: Deterministic<EdgeColor = bool> + Pointed {
     /// Uses a reference to `self` for creating a [`DBA`].

--- a/automata/src/automaton/dfa.rs
+++ b/automata/src/automaton/dfa.rs
@@ -101,6 +101,7 @@ pub trait DFALike: Deterministic<StateColor = bool> + Pointed
         DFA::from(self)
     }
 
+    /// Consumes and turns `self` into a [`DFA`]. Note, that this operation erases the edge colors.
     fn collect_dfa(self) -> DFA<Self::Alphabet> {
         DFA::from(self.erase_edge_colors().collect_with_initial())
     }

--- a/automata/src/automaton/dpa.rs
+++ b/automata/src/automaton/dpa.rs
@@ -222,7 +222,7 @@ impl<D: DPALike> IntoDPA<D> {
 
     /// Attempts to find an omega-word that witnesses the fact that `self` and `other` are not
     /// language-equivalent. If no such word exists, `None` is returned. Internally, this uses
-    /// [`witness_not_subset_of`] in both directions.
+    /// [`Self::witness_not_subset_of`] in both directions.
     pub fn witness_inequivalence<O: DPALike<Alphabet = D::Alphabet>>(
         &self,
         other: &IntoDPA<O>,

--- a/automata/src/automaton/dpa.rs
+++ b/automata/src/automaton/dpa.rs
@@ -1,4 +1,7 @@
-use std::{collections::VecDeque, marker::PhantomData};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    marker::PhantomData,
+};
 
 use itertools::Itertools;
 use tracing::{info, trace};
@@ -10,7 +13,7 @@ use crate::{
         operations::{MapEdgeColor, MapStateColor},
         CollectDTS, IntoInitialBTS, Quotient, Shrinkable,
     },
-    Parity, Partition, Set,
+    HasParity, Partition, Set,
 };
 
 use super::acceptor::OmegaWordAcceptor;
@@ -29,6 +32,8 @@ pub trait DPALike: Deterministic<EdgeColor = usize> + Pointed {
         DPA::from(self)
     }
 
+    /// Consumes `self` and returns a [`DPA`] from the transition system underlying `self`. Note
+    /// that this restricts to reachable states.
     fn collect_dpa(self) -> IntoDPA<Initialized<CollectDTS<Self>>> {
         DPA::from(self.trim_collect())
     }
@@ -54,14 +59,22 @@ impl<Ts: DPALike> AsRef<IntoDPA<Ts>> for IntoDPA<Ts> {
 }
 
 impl<D: DPALike> IntoDPA<D> {
+    /// Gives a witness for the fact that the language accepted by `self` is not empty. This is
+    /// done by finding an accepting cycle in the underlying transition system.
     pub fn give_word(&self) -> Option<Reduced<SymbolOf<Self>>> {
         todo!()
     }
 
+    /// Builds the complement of `self`, i.e. the DPA that accepts the complement of the language
+    /// accepted by `self`. This is a cheap operation as it only requires to increment all edge
+    /// colors by one.
     pub fn complement(self) -> DPA<D::Alphabet, D::StateColor> {
         self.map_edge_colors(|c| c + 1).collect_dpa()
     }
 
+    /// Gives a witness for the fact that `left` and `right` are not language-equivalent. This is
+    /// done by finding a separating word, i.e. a word that is accepted from one of the two states
+    /// but not by the other.
     pub fn separate<X, Y>(&self, left: X, right: Y) -> Option<Reduced<SymbolOf<Self>>>
     where
         X: Indexes<Self>,
@@ -79,12 +92,16 @@ impl<D: DPALike> IntoDPA<D> {
             .witness_inequivalence(&self.with_initial(q).into_dpa())
     }
 
-    pub fn prefix_congruence(&self) -> Quotient<&Self> {
-        fn print<X: Show>(part: &[Vec<X>]) -> String {
+    /// Computes a [`Partition`] of the state indices of `self` such that any two states in the
+    /// same class of the partition are language-equivalent. This is done iteratively, by considering each
+    /// state and finding a state that is language-equivalent to it. If no such state exists, a new
+    /// class is created.
+    pub fn prefix_partition(&self) -> Partition<D::StateIndex> {
+        fn print<X: Show>(part: &[BTreeSet<X>]) -> String {
             format!(
                 "{{{}}}",
                 part.iter()
-                    .map(|class| format!("[{}]", part.iter().map(|x| x.show()).join(", ")))
+                    .map(|class| format!("[{}]", class.iter().map(|x| x.show()).join(", ")))
                     .join(", ")
             )
         }
@@ -92,7 +109,7 @@ impl<D: DPALike> IntoDPA<D> {
         let fst = it.next();
         assert_eq!(fst, Some(self.initial()));
 
-        let mut partition = vec![vec![fst.unwrap()]];
+        let mut partition = vec![BTreeSet::from_iter([self.initial()])];
         let mut queue: VecDeque<_> = it.collect();
         let expected_size = queue.len() + 1;
 
@@ -108,7 +125,7 @@ impl<D: DPALike> IntoDPA<D> {
                     .expect("Class of partition must be non-empty");
                 if self
                     .as_ref()
-                    .with_initial(p)
+                    .with_initial(*p)
                     .as_dpa()
                     .language_equivalent(&self.as_ref().with_initial(q).as_dpa())
                 {
@@ -116,22 +133,30 @@ impl<D: DPALike> IntoDPA<D> {
                         "it is language equivalent to {}, adding it to the equivalence class",
                         p.show()
                     );
-                    partition.get_mut(i).unwrap().push(q);
+                    partition.get_mut(i).unwrap().insert(q);
                     continue 'outer;
                 }
             }
             trace!("not equivalent to any known states, creating a new equivalence class");
-            partition.push(vec![q]);
+            partition.push(BTreeSet::from_iter([q]));
         }
         debug_assert_eq!(
             partition.iter().fold(0, |acc, x| acc + x.len()),
             expected_size,
             "size mismatch!"
         );
-
-        self.quotient(Partition::new(partition))
+        partition.into()
     }
 
+    /// Builds the quotient of `self` with respect to the prefix partition. This will result in the prefix
+    /// congruence that underlies the language accepted by `self`.
+    pub fn prefix_congruence(&self) -> Quotient<&Self> {
+        self.quotient(self.prefix_partition())
+    }
+
+    /// Attempts to find an omega-word that witnesses the given `color`, meaning the least color that
+    /// appears infinitely often during the run of the returned word is equal to `color`. If no such
+    /// word exists, `None` is returned.
     pub fn witness_color(&self, color: D::EdgeColor) -> Option<Reduced<SymbolOf<Self>>> {
         let restrict = self.edge_color_restricted(color, usize::MAX);
         let sccs = restrict.sccs();
@@ -153,6 +178,10 @@ impl<D: DPALike> IntoDPA<D> {
         None
     }
 
+    /// Attempts to find an omega-word `w` such that the least color seen infinitely often
+    /// during the run of `self` on `w` is equal to `k` and the least color seen infinitely often
+    /// during the run of `other` on `w` is equal to `l`. If no such word exists, `None` is returned.
+    /// Main use of this is to witness the fact that `self` and `other` are not language-equivalent.
     pub fn witness_colors<O: DPALike<Alphabet = D::Alphabet>>(
         &self,
         k: usize,
@@ -186,10 +215,14 @@ impl<D: DPALike> IntoDPA<D> {
         None
     }
 
+    /// Returns an iterator over all colors that appear on edges of `self`.
     pub fn colors(&self) -> impl Iterator<Item = D::EdgeColor> + '_ {
         MealyLike::color_range(self)
     }
 
+    /// Attempts to find an omega-word that witnesses the fact that `self` and `other` are not
+    /// language-equivalent. If no such word exists, `None` is returned. Internally, this uses
+    /// [`witness_not_subset_of`] in both directions.
     pub fn witness_inequivalence<O: DPALike<Alphabet = D::Alphabet>>(
         &self,
         other: &IntoDPA<O>,
@@ -198,6 +231,8 @@ impl<D: DPALike> IntoDPA<D> {
             .or(other.witness_not_subset_of(self))
     }
 
+    /// Returns true if `self` is language-equivalent to `other`, i.e. if and only if the Two
+    /// DPAs accept the same language.
     pub fn language_equivalent<O: DPALike<Alphabet = D::Alphabet>>(
         &self,
         other: &IntoDPA<O>,
@@ -205,14 +240,20 @@ impl<D: DPALike> IntoDPA<D> {
         self.witness_inequivalence(other).is_none()
     }
 
+    /// Returns true if and only if `self` is included in `other`, i.e. if and only if the language
+    /// accepted by `self` is a subset of the language accepted by `other`.
     pub fn included_in<O: DPALike<Alphabet = D::Alphabet>>(&self, other: &IntoDPA<O>) -> bool {
         self.witness_not_subset_of(other).is_none()
     }
 
+    /// Returns true if and only if `self` includes `other`, i.e. if and only if the language
+    /// accepted by `self` is a superset of the language accepted by `other`.
     pub fn includes<O: DPALike<Alphabet = D::Alphabet>>(&self, other: &IntoDPA<O>) -> bool {
         other.witness_not_subset_of(self).is_none()
     }
 
+    /// Attempts to find an omega-word that witnesses the fact that `self` is not included in `other`.
+    /// If no such word exists, `None` is returned.
     pub fn witness_not_subset_of<O: DPALike<Alphabet = D::Alphabet>>(
         &self,
         other: &IntoDPA<O>,
@@ -233,6 +274,11 @@ impl<D: DPALike> IntoDPA<D> {
         None
     }
 
+    /// Produces a DPA that is language-equivalent to `self` but has the minimal number of different colors. This
+    /// done by a procedure which in essence was first introduced by Carton and Maceiras in their paper
+    /// "Computing the rabin index of a finite automaton". The procedure that this implementation actually uses
+    /// is outlined by Schewe and Ehlers in [Natural Colors of Infinite Words](https://arxiv.org/pdf/2207.11000.pdf)
+    /// in Section 4.1, Definition 2.
     pub fn normalized(&self) -> DPA<D::Alphabet, D::StateColor> {
         let start = std::time::Instant::now();
 
@@ -517,7 +563,7 @@ mod tests {
 
         let cong = dpa.prefix_congruence().collect_right_congruence_bare();
         assert_eq!(cong.size(), 2);
-        assert_eq!(cong.initial(), cong.reached("aa").unwrap());
+        assert_eq!(cong.initial(), cong.reached_state_index("aa").unwrap());
         assert!(cong.congruent("", "aa"));
         assert!(cong.congruent("ab", "baaba"));
 

--- a/automata/src/automaton/mealy.rs
+++ b/automata/src/automaton/mealy.rs
@@ -80,7 +80,7 @@ impl<Ts: TransitionSystem> TransitionSystem for MealyMachine<Ts::Alphabet, Ts::E
 
     type EdgeColor = Ts::EdgeColor;
 
-    type TransitionRef<'this> = Ts::TransitionRef<'this>
+    type EdgeRef<'this> = Ts::EdgeRef<'this>
     where
         Self: 'this;
 
@@ -115,7 +115,7 @@ impl<D: Deterministic> Deterministic for MealyMachine<D::Alphabet, D::EdgeColor,
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         self.ts().transition(state.to_index(self)?, symbol)
     }
 }
@@ -187,7 +187,7 @@ impl<Ts: TransitionSystem> MealyMachine<Ts::Alphabet, Ts::EdgeColor, Ts> {
 impl<Ts: PredecessorIterable> PredecessorIterable
     for MealyMachine<Ts::Alphabet, Ts::EdgeColor, Ts>
 {
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this>
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this>
     where
         Self: 'this;
 
@@ -273,7 +273,7 @@ macro_rules! impl_mealy_automaton {
         impl<Ts: PredecessorIterable> PredecessorIterable
             for $name<Ts::Alphabet, Ts::StateColor, Ts>
         {
-            type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+            type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
             type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
             fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
                 self.ts().predecessors(state)
@@ -345,7 +345,7 @@ macro_rules! impl_mealy_automaton {
             type StateIndex = Ts::StateIndex;
             type EdgeColor = Ts::EdgeColor;
             type StateColor = Ts::StateColor;
-            type TransitionRef<'this> = Ts::TransitionRef<'this> where Self: 'this;
+            type EdgeRef<'this> = Ts::EdgeRef<'this> where Self: 'this;
             type EdgesFromIter<'this> = Ts::EdgesFromIter<'this> where Self: 'this;
             type StateIndices<'this> = Ts::StateIndices<'this> where Self: 'this;
             type Alphabet = Ts::Alphabet;
@@ -382,7 +382,7 @@ macro_rules! impl_mealy_automaton {
                 &self,
                 state: Idx,
                 symbol: SymbolOf<Self>,
-            ) -> Option<Self::TransitionRef<'_>> {
+            ) -> Option<Self::EdgeRef<'_>> {
                 self.ts().transition(state.to_index(self)?, symbol)
             }
 

--- a/automata/src/automaton/mealy.rs
+++ b/automata/src/automaton/mealy.rs
@@ -224,9 +224,11 @@ impl<Ts: Deterministic> std::fmt::Debug for MealyMachine<Ts::Alphabet, Ts::EdgeC
 macro_rules! impl_mealy_automaton {
     ($name:ident, $color:ident) => {
         paste::paste! {
+            /// Type alias for considering `Ts` as an automaton.
             pub type [< Into $name >]<Ts> = $name<<Ts as TransitionSystem>::Alphabet, <Ts as TransitionSystem>::StateColor, Ts>;
         }
 
+        #[allow(missing_docs)]
         #[derive(Clone)]
         pub struct $name<
             A = Simple,
@@ -239,6 +241,7 @@ macro_rules! impl_mealy_automaton {
         impl<A: Alphabet, Q: Color + Default>
             $name<A, Q, Initialized<DTS<A, Q, $color>>>
         {
+            #[allow(missing_docs)]
             pub fn new(alphabet: A, initial_state_color: Q) -> $name<A, Q, Initialized<DTS<A, Q, $color>>> {
                 let mut ts = Initialized::new(alphabet);
                 ts.set_initial_color(initial_state_color);
@@ -248,6 +251,7 @@ macro_rules! impl_mealy_automaton {
                 }
             }
         }
+        #[allow(missing_docs)]
         impl<Ts: TransitionSystem> $name<Ts::Alphabet, Ts::StateColor, Ts> {
             pub fn ts(&self) -> &Ts {
                 &self.ts

--- a/automata/src/automaton/mod.rs
+++ b/automata/src/automaton/mod.rs
@@ -119,7 +119,7 @@ macro_rules! impl_automaton_type {
         impl<Ts: PredecessorIterable> PredecessorIterable
             for $name<Ts::Alphabet, Ts::StateColor, Ts::EdgeColor, Ts>
         {
-            type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+            type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
             type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
             fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
                 self.ts().predecessors(state)
@@ -195,7 +195,7 @@ macro_rules! impl_automaton_type {
             type StateIndex = Ts::StateIndex;
             type EdgeColor = Ts::EdgeColor;
             type StateColor = Ts::StateColor;
-            type TransitionRef<'this> = Ts::TransitionRef<'this> where Self: 'this;
+            type EdgeRef<'this> = Ts::EdgeRef<'this> where Self: 'this;
             type EdgesFromIter<'this> = Ts::EdgesFromIter<'this> where Self: 'this;
             type StateIndices<'this> = Ts::StateIndices<'this> where Self: 'this;
             fn state_indices(&self) -> Self::StateIndices<'_> {
@@ -223,7 +223,7 @@ macro_rules! impl_automaton_type {
                 &self,
                 state: Idx,
                 symbol: SymbolOf<Self>,
-            ) -> Option<Self::TransitionRef<'_>> {
+            ) -> Option<Self::EdgeRef<'_>> {
                 self.ts().transition(state.to_index(self)?, symbol)
             }
 

--- a/automata/src/automaton/mod.rs
+++ b/automata/src/automaton/mod.rs
@@ -42,6 +42,7 @@ pub use dpa::{DPALike, IntoDPA, DPA};
 mod dba;
 pub use dba::{DBALike, IntoDBA, DBA};
 
+#[allow(missing_docs)]
 mod omega;
 pub use omega::{
     AcceptanceMask, DeterministicOmegaAutomaton, OmegaAcceptanceCondition, OmegaAutomaton,

--- a/automata/src/automaton/moore.rs
+++ b/automata/src/automaton/moore.rs
@@ -61,7 +61,7 @@ impl<D: MooreLike + Deterministic> IntoMooreMachine<D> {
     /// for every finite word, the output of `self` and the output of the returned moore
     /// machine is the same. This is done using the Hopcroft and Moore algorithms for
     /// minimizing deterministic finite automata, implemented in the
-    /// [`moore_partition_refinement`] function.
+    /// [`crate::algorithms::moore_partition_refinement`] function.
     pub fn minimize(&self) -> AsMooreMachine<D> {
         crate::algorithms::moore_partition_refinement(self)
     }
@@ -76,7 +76,7 @@ impl<Ts: MooreLike> TransitionSystem
 
     type EdgeColor = Ts::EdgeColor;
 
-    type TransitionRef<'this> = Ts::TransitionRef<'this>
+    type EdgeRef<'this> = Ts::EdgeRef<'this>
     where
         Self: 'this;
 
@@ -112,7 +112,7 @@ impl<D: MooreLike> Deterministic for MooreMachine<D::Alphabet, D::StateColor, D:
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         self.ts().transition(state.to_index(self)?, symbol)
     }
 }
@@ -190,7 +190,7 @@ impl<Ts: MooreLike> MooreMachine<Ts::Alphabet, Ts::StateColor, Ts::EdgeColor, Ts
 impl<Ts: MooreLike + PredecessorIterable> PredecessorIterable
     for MooreMachine<Ts::Alphabet, Ts::StateColor, Ts::EdgeColor, Ts>
 {
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this>
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this>
     where
         Self: 'this;
 
@@ -276,7 +276,7 @@ macro_rules! impl_moore_automaton {
         impl<Ts: PredecessorIterable> PredecessorIterable
             for $name<Ts::Alphabet, Ts::EdgeColor, Ts>
         {
-            type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+            type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
             type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
             fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
                 self.ts().predecessors(state)
@@ -352,7 +352,7 @@ macro_rules! impl_moore_automaton {
             type StateIndex = Ts::StateIndex;
             type EdgeColor = Ts::EdgeColor;
             type StateColor = Ts::StateColor;
-            type TransitionRef<'this> = Ts::TransitionRef<'this> where Self: 'this;
+            type EdgeRef<'this> = Ts::EdgeRef<'this> where Self: 'this;
             type EdgesFromIter<'this> = Ts::EdgesFromIter<'this> where Self: 'this;
             type StateIndices<'this> = Ts::StateIndices<'this> where Self: 'this;
             type Alphabet = Ts::Alphabet;
@@ -380,21 +380,6 @@ macro_rules! impl_moore_automaton {
             }
         }
         impl<D: Deterministic> Deterministic for $name<D::Alphabet, D::EdgeColor, D> {
-            fn transition<Idx: $crate::prelude::Indexes<Self>>(
-                &self,
-                state: Idx,
-                symbol: SymbolOf<Self>,
-            ) -> Option<Self::TransitionRef<'_>> {
-                self.ts().transition(state.to_index(self)?, symbol)
-            }
-
-            fn edge_color(
-                &self,
-                state: Self::StateIndex,
-                expression: &ExpressionOf<Self>,
-            ) -> Option<EdgeColor<Self>> {
-                self.ts().edge_color(state, expression)
-            }
 
         }
         impl<Ts: Pointed> Pointed for $name<Ts::Alphabet, Ts::EdgeColor, Ts> {
@@ -447,7 +432,7 @@ pub trait MooreLike: Deterministic + Pointed {
 
     /// Returns true if `self` is bisimilar to `other`, i.e. if the two moore machines
     /// produce the same output for each finite word. This is done by checking whether
-    /// [`moore_witness_non_bisimilarity`] returns `None`.
+    /// [`Self::moore_witness_non_bisimilarity`] returns `None`.
     fn moore_bisimilar<M>(&self, other: M) -> bool
     where
         M: MooreLike<Alphabet = Self::Alphabet, StateColor = Self::StateColor>,

--- a/automata/src/automaton/moore.rs
+++ b/automata/src/automaton/moore.rs
@@ -34,6 +34,9 @@ pub type IntoMooreMachine<Ts> = MooreMachine<
     <Ts as TransitionSystem>::EdgeColor,
     Ts,
 >;
+/// Helper type that takes a pointed transition system and returns the corresponding
+/// [`MooreMachine`]. Note that this will consume the underlying ts and the given
+/// [`MooreMachine`] will use the default ts, which is `Initialized<DTS<A, Q, C>>`.
 pub type AsMooreMachine<Ts> = MooreMachine<
     <Ts as TransitionSystem>::Alphabet,
     <Ts as TransitionSystem>::StateColor,
@@ -54,12 +57,15 @@ impl<A: Alphabet, Q: Color, C: Color> MooreMachine<A, Q, C> {
 }
 
 impl<D: MooreLike + Deterministic> IntoMooreMachine<D> {
+    /// Returns the unique minimal moore machine that is bisimilar to `self`. This means
+    /// for every finite word, the output of `self` and the output of the returned moore
+    /// machine is the same. This is done using the Hopcroft and Moore algorithms for
+    /// minimizing deterministic finite automata, implemented in the
+    /// [`moore_partition_refinement`] function.
     pub fn minimize(&self) -> AsMooreMachine<D> {
         crate::algorithms::moore_partition_refinement(self)
     }
 }
-
-// impl_ts_by_passthrough_on_wrapper!(MooreMachine <Ts, Q: Color>);
 
 impl<Ts: MooreLike> TransitionSystem
     for MooreMachine<Ts::Alphabet, Ts::StateColor, Ts::EdgeColor, Ts>
@@ -429,6 +435,8 @@ pub trait MooreLike: Deterministic + Pointed {
             .collect()
     }
 
+    /// Builds a moore machine from a reference to `self`. Note that this allocates a new
+    /// transition system, which is a copy of the underlying one.
     fn collect_moore(&self) -> AsMooreMachine<Self> {
         let ts = self.collect_pointed();
         MooreMachine {
@@ -437,6 +445,9 @@ pub trait MooreLike: Deterministic + Pointed {
         }
     }
 
+    /// Returns true if `self` is bisimilar to `other`, i.e. if the two moore machines
+    /// produce the same output for each finite word. This is done by checking whether
+    /// [`moore_witness_non_bisimilarity`] returns `None`.
     fn moore_bisimilar<M>(&self, other: M) -> bool
     where
         M: MooreLike<Alphabet = Self::Alphabet, StateColor = Self::StateColor>,
@@ -444,6 +455,9 @@ pub trait MooreLike: Deterministic + Pointed {
         self.moore_witness_non_bisimilarity(other).is_none()
     }
 
+    /// Returns a witness for the non-bisimilarity of `self` and `other`, i.e. a finite word
+    /// that produces different outputs in the two moore machines. If the two machines are
+    /// bisimilar, `None` is returned.
     fn moore_witness_non_bisimilarity<M>(&self, other: M) -> Option<Vec<SymbolOf<Self>>>
     where
         M: MooreLike<Alphabet = Self::Alphabet, StateColor = Self::StateColor>,

--- a/automata/src/automaton/omega.rs
+++ b/automata/src/automaton/omega.rs
@@ -165,7 +165,7 @@ impl<A: Alphabet> TransitionSystem for OmegaAutomaton<A> {
 
     type EdgeColor = AcceptanceMask;
 
-    type TransitionRef<'this> = <DTS<A, usize, AcceptanceMask> as TransitionSystem>::TransitionRef<'this>
+    type EdgeRef<'this> = <DTS<A, usize, AcceptanceMask> as TransitionSystem>::EdgeRef<'this>
     where
         Self: 'this;
 
@@ -203,7 +203,7 @@ impl<A: Alphabet> TransitionSystem for DeterministicOmegaAutomaton<A> {
 
     type EdgeColor = AcceptanceMask;
 
-    type TransitionRef<'this> = <DTS<A, usize, AcceptanceMask> as TransitionSystem>::TransitionRef<'this>
+    type EdgeRef<'this> = <DTS<A, usize, AcceptanceMask> as TransitionSystem>::EdgeRef<'this>
     where
         Self: 'this;
 
@@ -235,7 +235,7 @@ impl<A: Alphabet> TransitionSystem for DeterministicOmegaAutomaton<A> {
 }
 
 impl<A: Alphabet> PredecessorIterable for OmegaAutomaton<A> {
-    type PreTransitionRef<'this> = <DTS<A, usize, AcceptanceMask> as PredecessorIterable>::PreTransitionRef<'this>
+    type PreEdgeRef<'this> = <DTS<A, usize, AcceptanceMask> as PredecessorIterable>::PreEdgeRef<'this>
     where
         Self: 'this;
 
@@ -249,7 +249,7 @@ impl<A: Alphabet> PredecessorIterable for OmegaAutomaton<A> {
 }
 
 impl<A: Alphabet> PredecessorIterable for DeterministicOmegaAutomaton<A> {
-    type PreTransitionRef<'this> = <DTS<A, usize, AcceptanceMask> as PredecessorIterable>::PreTransitionRef<'this>
+    type PreEdgeRef<'this> = <DTS<A, usize, AcceptanceMask> as PredecessorIterable>::PreEdgeRef<'this>
     where
         Self: 'this;
 
@@ -267,7 +267,7 @@ impl<A: Alphabet> Deterministic for DeterministicOmegaAutomaton<A> {
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         self.ts.transition(state.to_index(self)?, symbol)
     }
 }

--- a/automata/src/automaton/semantics.rs
+++ b/automata/src/automaton/semantics.rs
@@ -1,44 +1,85 @@
 use crate::{
     ts::{
         path::{Lasso, LassoIn},
-        Deterministic,
+        Deterministic, SymbolOf,
     },
+    word::OmegaWord,
     Color, Set,
 };
 
-pub trait FiniteSemantics<Q> {
-    fn finite_classify(&self, color: &Q) -> bool;
+use super::{Congruence, FiniteWord};
+
+pub type NewDFA<D> = Automaton<D, Boolean>;
+
+pub struct Automaton<D, A, const OMEGA: bool = false> {
+    pub ts: D,
+    pub acceptance: A,
 }
 
-pub trait OmegaSemantics<Q, C> {
-    fn omega_classify<P: ProvidesInfinitySets<Q, C>>(&self, infset: P) -> bool;
-}
-
-pub trait ProvidesInfinitySets<Q, C> {
-    fn recurrent_edges(self) -> impl Iterator<Item = C>;
-    fn recurrent_states(self) -> impl Iterator<Item = Q>;
-}
-
-impl<D: Deterministic> ProvidesInfinitySets<D::StateColor, D::EdgeColor> for (D, LassoIn<D>) {
-    fn recurrent_edges(self) -> impl Iterator<Item = D::EdgeColor> {
-        self.1.into_recurrent_edge_colors()
-    }
-
-    fn recurrent_states(self) -> impl Iterator<Item = D::StateColor> {
-        self.1.into_recurrent_state_colors()
+impl<D, A> Automaton<D, A> {
+    pub fn new(ts: D, acceptance: A) -> Self {
+        Self { ts, acceptance }
     }
 }
 
-pub struct ReachSingleColor<Q>(Q);
-impl<Q: Color> FiniteSemantics<Q> for ReachSingleColor<Q> {
-    fn finite_classify(&self, color: &Q) -> bool {
-        self.0.eq(color)
+impl<D, A> Automaton<D, A, false>
+where
+    D: Congruence,
+    A: FiniteSemantics<D>,
+{
+    pub fn accepts<W: FiniteWord<SymbolOf<D>>>(&self, word: W) -> A::Output {
+        self.acceptance.finite_semantic(&self.ts, word)
     }
 }
 
-pub struct ReachColors<Q>(Set<Q>);
-impl<Q: Color> FiniteSemantics<Q> for ReachColors<Q> {
-    fn finite_classify(&self, color: &Q) -> bool {
-        self.0.contains(color)
+impl<D, A> Automaton<D, A, true>
+where
+    D: Congruence,
+    A: OmegaSemantics<D>,
+{
+    pub fn accepts<W: OmegaWord<SymbolOf<D>>>(&self, word: W) -> A::Output {
+        self.acceptance.omega_semantic(&self.ts, word)
     }
+}
+
+pub trait HasParity {
+    fn parity(&self) -> bool;
+}
+
+impl HasParity for bool {
+    fn parity(&self) -> bool {
+        *self
+    }
+}
+
+impl HasParity for usize {
+    fn parity(&self) -> bool {
+        self % 2 == 1
+    }
+}
+
+pub struct Boolean;
+
+impl<D> FiniteSemantics<D> for Boolean
+where
+    D: Congruence,
+    D::StateColor: HasParity,
+{
+    type Output = bool;
+
+    fn finite_semantic<W: FiniteWord<SymbolOf<D>>>(&self, ts: &D, word: W) -> Self::Output {
+        ts.reached_state_color(word)
+            .map(|c| c.parity())
+            .unwrap_or(false)
+    }
+}
+
+pub trait FiniteSemantics<D: Congruence> {
+    type Output;
+    fn finite_semantic<W: FiniteWord<SymbolOf<D>>>(&self, ts: &D, word: W) -> Self::Output;
+}
+
+pub trait OmegaSemantics<D: Congruence> {
+    type Output;
+    fn omega_semantic<W: OmegaWord<SymbolOf<D>>>(&self, ts: &D, word: W) -> Self::Output;
 }

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -13,6 +13,7 @@ impl<Ts: TransitionSystem> Initialized<Ts> {
         &self.0
     }
 
+    /// Consumes and decomposes self into a tuple of the underlying transition system and the initial state.
     pub fn into_parts(self) -> (Ts, Ts::StateIndex) {
         (self.0, self.1)
     }

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -65,7 +65,7 @@ where
     C: Color,
     Q: Color,
 {
-    /// Takes an alphabet and a color and constructs a [`WithInitial`] instance with the given alphabet, no
+    /// Takes an alphabet and a color and constructs an [`Initialized`] instance with the given alphabet, no
     /// transitions and a single initial state with the given color.
     pub fn with_initial_color(alphabet: A, color: Q) -> Self {
         let mut ts = DTS::new_for_alphabet(alphabet);

--- a/automata/src/congruence/cayley.rs
+++ b/automata/src/congruence/cayley.rs
@@ -51,7 +51,7 @@ where
 
     type EdgeColor = ();
 
-    type TransitionRef<'this> = EdgeReference<'this, InvertibleChar, usize, ()> where Self: 'this;
+    type EdgeRef<'this> = EdgeReference<'this, InvertibleChar, usize, ()> where Self: 'this;
 
     type StateIndices<'this> = std::ops::Range<usize> where Self: 'this;
 
@@ -85,7 +85,7 @@ where
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         let idx = state.to_index(self)?;
         let (tp, string) = self.monoid().get_profile(idx)?;
         let mut word = string.to_deque();
@@ -192,7 +192,7 @@ where
 
     type EdgeColor = ();
 
-    type TransitionRef<'this> = EdgeReference<'this, ExpressionOf<Ts>, usize, ()> where Self: 'this;
+    type EdgeRef<'this> = EdgeReference<'this, ExpressionOf<Ts>, usize, ()> where Self: 'this;
 
     type StateIndices<'this> = std::ops::Range<usize> where Self: 'this;
 
@@ -225,7 +225,7 @@ where
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         let idx = state.to_index(self)?;
         let (tp, string) = self.monoid().get_profile(idx)?;
         let mut word = string.to_vec();

--- a/automata/src/congruence/forc.rs
+++ b/automata/src/congruence/forc.rs
@@ -46,6 +46,7 @@ impl<A: Alphabet, Q: Color, C: Color> FORC<A, Q, C> {
         self.progress.get(&idx)
     }
 
+    /// Returns an iterator over the progress congruences.
     pub fn prc_iter(&self) -> impl Iterator<Item = (&'_ usize, &'_ RightCongruence<A, Q, C>)> + '_ {
         self.progress.iter()
     }

--- a/automata/src/congruence/mod.rs
+++ b/automata/src/congruence/mod.rs
@@ -62,7 +62,7 @@ impl<A: Alphabet, Q: Color, C: Color> RightCongruence<A, Q, C> {
         W: FiniteWord<A::Symbol>,
         V: FiniteWord<A::Symbol>,
     {
-        self.reached(word).unwrap() == self.reached(other).unwrap()
+        self.reached_state_index(word).unwrap() == self.reached_state_index(other).unwrap()
     }
 
     /// Turns the given transition system into a right congruence.
@@ -92,7 +92,7 @@ impl<A: Alphabet, Q: Color, C: Color> RightCongruence<A, Q, C> {
     /// with the corresponding index of the class.
     pub fn classes(&self) -> impl Iterator<Item = (Class<A::Symbol>, usize)> + '_ {
         self.ts
-            .indices_with_color()
+            .state_indices_with_color()
             .map(|(id, c)| (c.class().clone(), id))
     }
 
@@ -126,11 +126,16 @@ impl<A: Alphabet, Q: Color, C: Color> RightCongruence<A, Q, C> {
     #[inline(always)]
     /// Returns the index of the class containing the given word.
     pub fn class_to_index(&self, class: &Class<A::Symbol>) -> Option<usize> {
-        self.ts
-            .indices_with_color()
-            .find_map(|(id, c)| if c.class() == class { Some(id) } else { None })
+        self.ts.state_indices_with_color().find_map(|(id, c)| {
+            if c.class() == class {
+                Some(id)
+            } else {
+                None
+            }
+        })
     }
 
+    /// Returns the [`ColoredClass`] that is referenced by `index`.
     pub fn class_name<Idx: Indexes<Self>>(&self, index: Idx) -> Option<ColoredClass<A::Symbol, Q>> {
         self.ts().state_color(index.to_index(self)?)
     }

--- a/automata/src/congruence/transitionprofile.rs
+++ b/automata/src/congruence/transitionprofile.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt::{Debug, Display},

--- a/automata/src/hoa/input.rs
+++ b/automata/src/hoa/input.rs
@@ -12,6 +12,8 @@ use crate::{
 
 use super::HoaAlphabet;
 
+/// Considers the given HOA string as a single automaton and tries to parse it into an
+/// [`OmegaAutomaton`].
 pub fn hoa_to_ts(hoa: &str) -> Vec<OmegaAutomaton<HoaAlphabet>> {
     let mut out = vec![];
     for hoa_aut in hoars::parse_hoa_automata(hoa) {
@@ -43,6 +45,8 @@ impl TryFrom<HoaAutomaton> for OmegaAutomaton<HoaAlphabet> {
     }
 }
 
+/// Converts a [`HoaAutomaton`] into a [`NTS`] with the same semantics. This creates the appropriate
+/// number of states and inserts transitions with the appropriate labels and colors.
 pub fn hoa_automaton_to_nts(
     aut: HoaAutomaton,
 ) -> Initialized<NTS<HoaAlphabet, usize, AcceptanceMask>> {

--- a/automata/src/hoa/mod.rs
+++ b/automata/src/hoa/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 pub mod input;
 pub mod output;
 

--- a/automata/src/hoa/mod.rs
+++ b/automata/src/hoa/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     Alphabet, Map, Pointed, Show, TransitionSystem,
 };
 
-/// A propositional alphabet, where a [`Symbol`] is a valuation of all propositional variables.
+/// A propositional alphabet, where a symbol is a valuation of all propositional variables.
 ///
 /// # Example
 /// Assume we have a propositional alphabet over the atomic propositions `a`, `b` and `c`.

--- a/automata/src/length.rs
+++ b/automata/src/length.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 
 /// Abstracts the concept of length, allowing us to work with finite and infinite words in a
 /// somewhat similar fashion.
+// TODO: DEPRECATE
 pub trait Length: Eq + Ord + Hash + Debug + Display + Copy {
     /// Whether the length is finite or not.
     // FIXME: remove or improve
@@ -10,7 +11,7 @@ pub trait Length: Eq + Ord + Hash + Debug + Display + Copy {
     /// The type of iterator over the set of raw positions.
     type RawPositions: Iterator<Item = RawPosition>;
 
-    /// Heavily used in the computation of a run (see [`crate::ts::run::walker::Walker`]). For
+    /// Heavily used in the computation of a run but most probably deprecated. For
     /// finite words, this method always either returns `None` (if the given `position` is out
     /// of bounds) or `Some(position)`. More interestingly, if the length is infinite, this
     /// method takes the reset point/loop index of the input into account.

--- a/automata/src/lib.rs
+++ b/automata/src/lib.rs
@@ -15,7 +15,7 @@
 //! - [`Pointed`] which picks one designated initial state, this is important for deterministic automata
 //! - [`Deterministic`], a marker trait that disambiguates between nondeterministic and deterministic TS. As [`TransitionSystem`] only provides iterators over the outgoing edges, it can be used to deal with nondeterministic TS, that have multiple overlapping edges. By implementing `Deterministic`, we guarantee, that there is always a single unique outgoing transition for each state.
 //! - [`Sproutable`] enables growing a TS state by state and edge/transition by edge/transition. Naturally, this is only implemented for the basic building blocks, i.e. `BTS`, `DTS` and `NTS`.
-//!
+#![warn(missing_docs)]
 #![allow(unused)]
 #![allow(clippy::pedantic)]
 
@@ -58,7 +58,7 @@ use itertools::Itertools;
 
 /// Defines lengths of finite and infinite words.
 pub mod length;
-use std::hash::Hash;
+use std::{collections::BTreeSet, hash::Hash};
 
 /// Module that contains definitions for dealing with lengths. This is particularly
 /// useful for dealing with infinite words.
@@ -85,11 +85,13 @@ pub mod word;
 /// Module that contains definitions for dealing with mappings.
 pub mod mapping;
 
+/// Contains implementations for different algorithms such as minimization.
 pub mod algorithms;
 
 #[feature(hoa)]
 pub mod hoa;
 
+/// Implements the generation of random transition systems.
 #[feature(random)]
 pub mod random;
 
@@ -111,8 +113,15 @@ pub type Set<S> = fxhash::FxHashSet<S>;
 /// Type alias for maps, we use this to hide which type of `HashMap` we are actually using.
 pub type Map<K, V> = fxhash::FxHashMap<K, V>;
 
+/// Helper trait which can be used to display states, transitions and such.
 pub trait Show {
+    /// Returns a human readable representation of `self`, for a state index that should be
+    /// for example q0, q1, q2, ... and for a transition (q0, a, q1) it should be (q0, a, q1).
+    /// Just use something that makes sense. This is mainly used for debugging purposes.
     fn show(&self) -> String;
+    /// Show a collection of the thing, for a collection of states this should be {q0, q1, q2, ...}
+    /// and for a collection of transitions it should be {(q0, a, q1), (q1, b, q2), ...}.
+    /// By default this is unimplemented.
     fn show_collection<'a, I>(iter: I) -> String
     where
         Self: 'a,
@@ -240,11 +249,11 @@ impl Show for bool {
 /// type `I` into their respective classes under the relation.
 #[derive(Debug, Clone)]
 #[autoimpl(Deref using self.0)]
-pub struct Partition<I: Hash + Eq>(Vec<Set<I>>);
+pub struct Partition<I: Hash + Eq>(Vec<BTreeSet<I>>);
 
 impl<'a, I: Hash + Eq> IntoIterator for &'a Partition<I> {
-    type Item = &'a Set<I>;
-    type IntoIter = std::slice::Iter<'a, Set<I>>;
+    type Item = &'a BTreeSet<I>;
+    type IntoIter = std::slice::Iter<'a, BTreeSet<I>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -258,7 +267,8 @@ impl<I: Hash + Eq> PartialEq for Partition<I> {
 }
 impl<I: Hash + Eq> Eq for Partition<I> {}
 
-impl<I: Hash + Eq> Partition<I> {
+impl<I: Hash + Eq + Ord> Partition<I> {
+    /// Returns the size of the partition, i.e. the number of classes.
     pub fn size(&self) -> usize {
         self.0.len()
     }
@@ -268,30 +278,35 @@ impl<I: Hash + Eq> Partition<I> {
     pub fn new<X: IntoIterator<Item = I>, Y: IntoIterator<Item = X>>(iter: Y) -> Self {
         Self(
             iter.into_iter()
-                .map(|it| it.into_iter().collect::<Set<_>>())
+                .map(|it| it.into_iter().collect::<BTreeSet<_>>())
                 .collect(),
         )
     }
 }
 
-impl<I: Hash + Eq> From<Vec<Set<I>>> for Partition<I> {
-    fn from(value: Vec<Set<I>>) -> Self {
+impl<I: Hash + Eq + Ord> From<Vec<BTreeSet<I>>> for Partition<I> {
+    fn from(value: Vec<BTreeSet<I>>) -> Self {
         Self(value)
     }
 }
 
-pub trait Parity {
+/// Captures types that have a parity. This is used for example to determine whether a state
+/// is even or odd. We extend this notion to boolean values by assuming that `true` is even
+/// and `false` is odd.
+pub trait HasParity {
+    #[allow(missing_docs)]
     fn is_even(&self) -> bool;
+    #[allow(missing_docs)]
     fn is_odd(&self) -> bool {
         !self.is_even()
     }
 }
-impl<P: Parity> Parity for &P {
+impl<P: HasParity> HasParity for &P {
     fn is_even(&self) -> bool {
         P::is_even(self)
     }
 }
-impl Parity for usize {
+impl HasParity for usize {
     fn is_even(&self) -> bool {
         self % 2 == 0
     }

--- a/automata/src/lib.rs
+++ b/automata/src/lib.rs
@@ -8,14 +8,15 @@
 //! As each combinator returns an object which again implements [`TransitionSystem`], these can easily be chained together without too much overhead. While this is convenient, the applied manipulations are computed on-demand, which may lead to considerable overhead. To circumvent this, it can be beneficial to `collect` the resulting TS into a structure, which then explicitly does all the necessary computations and avoids recomputation at a later point. There are also variants `collect_with_initial`/`collect_ts`, which either take the designated ininital state into account or collect into a specific representation of the TS.
 //!
 //! The crate defines some basic building blocks of TS which can easily be manipulated (see `Sproutable`), these are
-//! - [`NTS`]/[`DTS`] (the latter is just a thin wrapper around the former). These store edges in a vector, a state contains a pointer to the first edge in this collection and each edge contains pointers to the previous/next one.
-//! - [`BTS`] which stores transitions in an efficient HashMap
+//! - [`ts::NTS`]/[`ts::DTS`] (the latter is just a thin wrapper around the former). These store edges in a vector, a state contains a pointer to the first edge in this collection and each edge contains pointers to the previous/next one.
+//! - [`ts::BTS`] which stores transitions in an efficient HashMap
 //!
 //! Further traits that are of importance are
 //! - [`Pointed`] which picks one designated initial state, this is important for deterministic automata
-//! - [`Deterministic`], a marker trait that disambiguates between nondeterministic and deterministic TS. As [`TransitionSystem`] only provides iterators over the outgoing edges, it can be used to deal with nondeterministic TS, that have multiple overlapping edges. By implementing `Deterministic`, we guarantee, that there is always a single unique outgoing transition for each state.
-//! - [`Sproutable`] enables growing a TS state by state and edge/transition by edge/transition. Naturally, this is only implemented for the basic building blocks, i.e. `BTS`, `DTS` and `NTS`.
-#![warn(missing_docs)]
+//! - [`ts::Deterministic`], a marker trait that disambiguates between nondeterministic and deterministic TS. As [`TransitionSystem`] only provides iterators over the outgoing edges, it can be used to deal with nondeterministic TS, that have multiple overlapping edges. By implementing `Deterministic`, we guarantee, that there is always a single unique outgoing transition for each state.
+//! - [`ts::Sproutable`] enables growing a TS state by state and edge/transition by edge/transition. Naturally, this is only implemented for the basic building blocks, i.e. `BTS`, `DTS` and `NTS`.
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![allow(unused)]
 #![allow(clippy::pedantic)]
 
@@ -27,9 +28,9 @@ pub mod prelude {
         alphabet::{Expression, Simple, Symbol},
         automaton::{
             DBALike, DFALike, DPALike, FiniteWordAcceptor, FiniteWordTransformer, Initialized,
-            IntoMealyMachine, IntoMooreMachine, MealyLike, MealyMachine, MooreLike, MooreMachine,
-            NoColor, OmegaWordAcceptor, OmegaWordTransformer, StateBasedDBA, StateBasedDPA, DBA,
-            DFA, DPA,
+            IntoDBA, IntoDFA, IntoDPA, IntoMealyMachine, IntoMooreMachine, MealyLike, MealyMachine,
+            MooreLike, MooreMachine, NoColor, OmegaWordAcceptor, OmegaWordTransformer,
+            StateBasedDBA, StateBasedDPA, DBA, DFA, DPA,
         },
         mapping::Morphism,
         ts::{
@@ -38,10 +39,12 @@ pub mod prelude {
             finite::ReachedState,
             operations::{Product, ProductIndex},
             predecessors::PredecessorIterable,
-            transition_system::{EdgeColorOf, EdgeReference, Indexes, IsEdge, StateColorOf},
+            transition_system::{
+                EdgeColorOf, EdgeReference, FullTransition, Indexes, IsEdge, StateColorOf,
+            },
             Congruence, Deterministic, DeterministicEdgesFrom, EdgeColor, ExpressionOf, HasColor,
-            HasColorMut, HasMutableStates, HasStates, IndexType, NTSBuilder, Sproutable,
-            StateColor, SymbolOf, TransitionSystem, BTS, DTS, NTS,
+            HasColorMut, HasMutableStates, HasStates, IndexType, Path, Sproutable, StateColor,
+            SymbolOf, TSBuilder, TransitionSystem, BTS, DTS, NTS,
         },
         upw,
         word::{FiniteWord, LinearWord, OmegaWord, Periodic, Reduced, ReducedParseError},

--- a/automata/src/random.rs
+++ b/automata/src/random.rs
@@ -2,6 +2,14 @@ use tracing::{debug, info, trace};
 
 use crate::{prelude::*, Map};
 
+/// Uses sprout-like algorithm to generate a random transition system. `symbols` determines the
+/// number of distinct symbols in the [`Simple`] alphabet. `probability` determines the probability
+/// of a back edge to some state being inserted. The algorithm is as follows:
+/// 1. Start with a single state.
+/// 2. For each symbol, go through the existing states in order and with probability `probability`
+///   add a back edge that state.
+/// 3. If no back edge to some state was added, we insert an edge to a new state.
+/// 4. Repeat until all states and symbols have been treated.
 pub fn generate_random_ts(symbols: usize, probability: f64) -> Initialized<DTS> {
     let alphabet = Simple::alphabetic(symbols);
     let mut dts = DTS::new_for_alphabet(alphabet.clone());
@@ -41,6 +49,7 @@ pub fn generate_random_ts(symbols: usize, probability: f64) -> Initialized<DTS> 
     dts.with_initial(0)
 }
 
+/// Works as [`generate_random_ts`], but returns a [`DFA`] instead by randomly coloring the states.
 pub fn generate_random_dfa(symbols: usize, probability: f64) -> DFA {
     generate_random_ts(symbols, probability)
         .map_state_colors(|_| fastrand::bool())

--- a/automata/src/ts/builder.rs
+++ b/automata/src/ts/builder.rs
@@ -1,0 +1,183 @@
+use itertools::Itertools;
+
+use crate::prelude::*;
+
+/// Helper struct for the construction of non-deterministic transition systems. It stores a list of edges, a list of colors and a default color.
+/// This can also be used to construct deterministic transition systems, deterministic parity automata and Mealy machines.
+///
+/// # Example
+///
+/// We want to create a DFA with two states 0 and 1 over the alphabet `['a', 'b']`. We want to add the following transitions:
+/// - From state 0 to state 0 on symbol 'a'
+/// - From state 0 to state 1 on symbol 'b'
+/// - From state 1 to state 1 on symbol 'a'
+/// - From state 1 to state 0 on symbol 'b'
+/// Further, state 0 should be initial and colored `true` and state 1 should be colored `false`. This can be done as follows
+/// ```
+/// use automata::prelude::*;
+///
+/// let mut nts = NTS::builder()
+///     .with_colors([true, false]) // colors given in the order of the states
+///     .with_transitions([(0, 'a', (), 0), (0, 'b', (), 1), (1, 'a', (), 1), (1, 'b', (), 0)])
+///     .into_dfa(0); // 0 is the initial state
+/// ```
+pub struct TSBuilder<Q = (), C = ()> {
+    edges: Vec<(usize, char, C, usize)>,
+    default: Option<Q>,
+    colors: Vec<(usize, Q)>,
+}
+
+impl<Q, C> Default for TSBuilder<Q, C> {
+    fn default() -> Self {
+        Self {
+            edges: vec![],
+            default: None,
+            colors: vec![],
+        }
+    }
+}
+
+impl TSBuilder<bool, ()> {
+    /// Tries to turn `self` into a deterministic finite automaton. Panics if `self` is not deterministic.
+    pub fn into_dfa(mut self, initial: usize) -> DFA<Simple> {
+        self.deterministic().with_initial(initial).collect_dfa()
+    }
+}
+
+impl TSBuilder<(), usize> {
+    /// Attempts to turn `self` into a deterministic parity automaton. Panics if `self` is not deterministic.
+    pub fn into_dpa(mut self, initial: usize) -> DPA<Simple> {
+        self.default_color(())
+            .deterministic()
+            .with_initial(initial)
+            .collect_dpa()
+    }
+
+    /// Builds a Mealy machine from `self`. Panics if `self` is not deterministic.
+    pub fn into_mealy_machine(mut self, initial: usize) -> MealyMachine<Simple> {
+        self.default_color(())
+            .deterministic()
+            .with_initial(initial)
+            .into_mealy()
+    }
+}
+
+impl TSBuilder {
+    /// Turns `self` into a [`RightCongruence`] with the given initial state while also erasing all state and edge
+    /// colors. Panics if `self` is not deterministic.
+    pub fn into_right_congruence_bare(self, initial: usize) -> RightCongruence<Simple> {
+        self.default_color(())
+            .deterministic()
+            .with_initial(initial)
+            .collect_right_congruence_bare()
+    }
+}
+
+impl<Q: Color, C: Color> TSBuilder<Q, C> {
+    /// Sets the default color for states that have no color specified.
+    pub fn default_color(mut self, color: Q) -> Self {
+        self.default = Some(color);
+        self
+    }
+
+    /// Adds a list of colors to `self`. The colors are assigned to the states in the order in which they are given.
+    /// This means if we give the colors `[true, false]` and then add a transition from state `0` to state `1`, then state
+    /// `0` will have color `true` and state `1` will have color `false`.
+    pub fn with_colors<I: IntoIterator<Item = Q>>(mut self, iter: I) -> Self {
+        iter.into_iter()
+            .enumerate()
+            .fold(self, |mut acc, (i, x)| acc.color(i, x))
+    }
+
+    /// Build a deterministic transition system from `self`. Panics if `self` is not deterministic.
+    pub fn deterministic(mut self) -> DTS<Simple, Q, C>
+    where
+        Q: Color,
+        C: Color,
+    {
+        self.collect().try_into().expect("Not deterministic!")
+    }
+
+    /// Assigns the given `color` to the state with the given index `idx`.
+    pub fn color(mut self, idx: usize, color: Q) -> Self
+    where
+        Q: Color,
+    {
+        assert!(self.colors.iter().all(|(q, c)| q != &idx || c == &color));
+        self.colors.push((idx, color));
+        self
+    }
+
+    /// Adds a list of transitions to `self`. The transitions are added in the order in which they are given.
+    /// The transitions can be passed in as anything that is iterable. An easy way is to pass in an array of tuples.
+    ///
+    /// # Example
+    ///
+    /// We want to create a DFA with two states 0 and 1 over the alphabet `['a', 'b']`. We want to add the following transitions:
+    /// - From state 0 to state 0 on symbol 'a'
+    /// - From state 0 to state 1 on symbol 'b'
+    /// - From state 1 to state 1 on symbol 'a'
+    /// - From state 1 to state 0 on symbol 'b'
+    /// Further, state 0 should be initial and colored `true` and state 1 should be colored `false`. This can be done as follows
+    /// ```
+    /// use automata::prelude::*;
+    ///
+    /// let mut nts = NTS::builder()
+    ///     .with_colors([true, false]) // colors given in the order of the states
+    ///     .with_transitions([(0, 'a', (), 0), (0, 'b', (), 1), (1, 'a', (), 1), (1, 'b', (), 0)])
+    ///     .into_dfa(0); // 0 is the initial state
+    /// ```
+    pub fn with_transitions<X: FullTransition<usize, char, C>, T: IntoIterator<Item = X>>(
+        mut self,
+        iter: T,
+    ) -> Self {
+        self.edges.extend(iter.into_iter().map(|t| t.clone_tuple()));
+        self
+    }
+
+    /// Turns `self` into a [`RightCongruence`] with the given initial state. Panics if `self` is not deterministic.
+    pub fn into_right_congruence(self, initial: usize) -> RightCongruence<Simple, Q, C> {
+        self.deterministic()
+            .with_initial(initial)
+            .collect_right_congruence()
+    }
+
+    /// Collects self into a non-deterministic transition system.
+    pub fn collect(mut self) -> NTS<Simple, Q, C>
+    where
+        Q: Color,
+        C: Color,
+    {
+        let alphabet = Simple::from_iter(self.edges.iter().map(|(_, a, _, _)| *a));
+        let num_states = self
+            .edges
+            .iter()
+            .flat_map(|(q, _, _, p)| [*p, *q])
+            .unique()
+            .count();
+        let mut ts = NTS::new_for_alphabet(alphabet);
+        let colors_it = (0..num_states).map(|x| {
+            if let Some(color) =
+                self.colors
+                    .iter()
+                    .find_map(|(q, c)| if *q == x { Some(c.clone()) } else { None })
+            {
+                color
+            } else {
+                self.default.clone().unwrap_or_else(|| {
+                    panic!(
+                        "Default is needed as some states (specifically {}) have no color",
+                        x.show()
+                    )
+                })
+            }
+        });
+        let created_states_number = ts.extend_states(colors_it).count();
+        assert_eq!(created_states_number, num_states);
+
+        for (p, a, c, q) in self.edges {
+            ts.add_edge(p, a, q, c);
+        }
+        ts
+    }
+}

--- a/automata/src/ts/connected_components/mod.rs
+++ b/automata/src/ts/connected_components/mod.rs
@@ -37,6 +37,8 @@ impl<'a, Ts: TransitionSystem> SccDecomposition<'a, Ts> {
         Self(ts, sccs)
     }
 
+    /// Gives the first [`Scc`] in the decomposition. This must exist as we only allow
+    /// non-empty decompositions.
     pub fn first(&self) -> &Scc<'a, Ts> {
         self.1.first().expect("At least one SCC must exist!")
     }
@@ -50,6 +52,8 @@ impl<'a, Ts: TransitionSystem> SccDecomposition<'a, Ts> {
             .find_map(|(i, scc)| if scc.contains(&state) { Some(i) } else { None })
     }
 
+    /// Tests whether two SCC decompositions are isomorphic. This is done by checking whether each
+    /// SCC in one decomposition has a matching SCC in the other decomposition.
     pub fn isomorphic(&self, other: &SccDecomposition<'a, Ts>) -> bool {
         for scc in &self.1 {
             if !other.1.iter().any(|other_scc| scc == other_scc) {

--- a/automata/src/ts/connected_components/scc.rs
+++ b/automata/src/ts/connected_components/scc.rs
@@ -98,15 +98,21 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
         })
     }
 
+    /// Returns the size, i.e. the number of states in the SCC.
     pub fn size(&self) -> usize {
         assert!(!self.is_empty());
         self.states.len()
     }
 
+    /// Returns `true` iff the SCC is trivial, meaning it consists of a single state.
     pub fn is_trivial(&self) -> bool {
         self.size() == 1
     }
 
+    /// Gives a reference to all interior edges of the SCC. An interior edge is an edge whose source
+    /// and target states are in the SCC itself.
+    ///
+    /// This is computed lazily and cached.
     pub fn interior_edges(&self) -> &InteriorEdgeSet<Ts> {
         self.edges.get_or_init(|| {
             let mut edges = Set::default();
@@ -123,6 +129,10 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
         })
     }
 
+    /// Gives a reference to all interior transitions of the SCC. An interior transitions is one whose source
+    /// and target states are in the SCC itself.
+    ///
+    /// This is computed lazily and cached.
     pub fn interior_transitions(&self) -> &InteriorTransitionSet<Ts> {
         self.transitions.get_or_init(|| {
             let mut edges = Set::default();
@@ -179,6 +189,9 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
         )
     }
 
+    /// Attempts to compute a maximal word which is one that visits all states in the scc and uses
+    /// each interior transition (one whose source and target are within the SCC) at least once.
+    /// If no such word exists, `None` is returned.
     pub fn maximal_word(&self) -> Option<Vec<SymbolOf<Ts>>> {
         self.maximal_loop_from(*self.states.first()?)
     }

--- a/automata/src/ts/connected_components/tarjan_dag.rs
+++ b/automata/src/ts/connected_components/tarjan_dag.rs
@@ -26,7 +26,7 @@ pub struct TarjanDAG<'a, Ts: TransitionSystem> {
 impl<'a, Ts: TransitionSystem> TarjanDAG<'a, Ts> {
     /// Returns an iterator over all transient edges in the transition system. An edge is transient
     /// if its source and target are in different SCCs.
-    pub fn transient_edges(&self) -> impl Iterator<Item = Ts::TransitionRef<'a>> + '_ {
+    pub fn transient_edges(&self) -> impl Iterator<Item = Ts::EdgeRef<'a>> + '_ {
         self.ts.transitions().filter(move |t| {
             let source = t.source();
             let target = t.target();

--- a/automata/src/ts/dag.rs
+++ b/automata/src/ts/dag.rs
@@ -28,7 +28,7 @@ impl<C> Dag<C> {
 
     /// Returns an iterator over the indices of all nodes in the DAG.
     pub fn node_indices(&self) -> impl Iterator<Item = usize> + '_ {
-        (0..self.nodes.len()).into_iter()
+        0..self.nodes.len()
     }
 
     /// Returns true iff the graph is empty, i.e. there are no nodes.

--- a/automata/src/ts/deterministic.rs
+++ b/automata/src/ts/deterministic.rs
@@ -23,9 +23,12 @@ use super::operations::StateIndexFilter;
 use super::path::Lasso;
 use super::path::LassoIn;
 use super::path::PathIn;
+use super::reachable::MinimalRepresentative;
 use super::sproutable::{IndexedAlphabet, Sproutable};
 use super::Path;
 
+/// A marker tait indicating that a [`TransitionSystem`] is deterministic, meaning for every state and
+/// each possible input symbol from the alphabet, there is at most one transition.
 pub trait Deterministic: TransitionSystem {
     /// For a given `state` and `symbol`, returns the transition that is taken, if it exists.
     fn transition<Idx: Indexes<Self>>(
@@ -58,6 +61,8 @@ pub trait Deterministic: TransitionSystem {
         Some(self.transition(state, sym)?.color().clone())
     }
 
+    /// Attempts to find the minimal representative of the indexed `state`, which the the length-lexicographically
+    /// minimal word that can be used to reach `state`. If `state` is not reachable, `None` is returned.
     fn minimal_representative<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Vec<SymbolOf<Self>>>
     where
         Self: Pointed,
@@ -67,6 +72,8 @@ pub trait Deterministic: TransitionSystem {
             .find_map(|(rep, p)| if p == q { Some(rep) } else { None })
     }
 
+    /// Gives an iterator over the minimal transition representatives, which are the length-lexicographically
+    /// minimal words that can be used to use a transition. The iterator returns only unique elements.
     fn minimal_transition_representatives(&self) -> impl Iterator<Item = Vec<SymbolOf<Self>>>
     where
         Self: Pointed,
@@ -84,6 +91,10 @@ pub trait Deterministic: TransitionSystem {
     ///  can be taken),
     /// - [`Err`] if the run is unsuccessful, meaning a symbol is encountered for which no
     /// transition exists.
+    ///
+    /// It returns a [`PathIn`] in either case, which is a path in the transition system. So it is possible
+    /// to inspect the path, e.g. to find out which state was reached or which transitions were taken.
+    /// For more information, see [`automata::ts::Path`].
     #[allow(clippy::type_complexity)]
     fn finite_run<W: FiniteWord<SymbolOf<Self>>>(
         &self,
@@ -93,26 +104,6 @@ pub trait Deterministic: TransitionSystem {
         Self: Pointed,
     {
         self.finite_run_from(word, self.initial())
-    }
-
-    fn reached_from<W, Idx>(&self, word: W, origin: Idx) -> Option<Self::StateIndex>
-    where
-        W: FiniteWord<SymbolOf<Self>>,
-        Idx: Indexes<Self>,
-    {
-        self.finite_run_from(word, origin.to_index(self)?)
-            .ok()
-            .map(|x| x.reached())
-    }
-
-    fn reached<W>(&self, word: W) -> Option<Self::StateIndex>
-    where
-        W: FiniteWord<SymbolOf<Self>>,
-        Self: Pointed,
-    {
-        self.finite_run_from(word, self.initial())
-            .ok()
-            .map(|x| x.reached())
     }
 
     /// Runs the given `word` on the transition system, starting from `state`. The result is
@@ -141,6 +132,8 @@ pub trait Deterministic: TransitionSystem {
         Ok(path)
     }
 
+    /// Runs the given `word` from the `origin` state. If the run is successful, the function returns the indices
+    /// of all states which appear infinitely often. For unsuccessful runs, `None` is returned.
     fn recurrent_state_indices_from<W: OmegaWord<SymbolOf<Self>>, Idx: Indexes<Self>>(
         &self,
         word: W,
@@ -153,6 +146,8 @@ pub trait Deterministic: TransitionSystem {
         )
     }
 
+    /// Returns an iterator over the state indices that are visited infinitely often when running the given `word`
+    /// on the transition system, starting from the initial state. If the run is unsuccessful, `None` is returned.
     fn recurrent_state_indices<W: OmegaWord<SymbolOf<Self>>>(
         &self,
         word: W,
@@ -163,6 +158,8 @@ pub trait Deterministic: TransitionSystem {
         self.recurrent_state_indices_from(word, self.initial())
     }
 
+    /// Returns an iterator yielding the colors of states which are visited infinitely often when running the given `word`
+    /// on the transition system, starting from the initial state. If the run is unsuccessful, `None` is returned.  
     fn recurrent_state_colors_from<W: OmegaWord<SymbolOf<Self>>, Idx: Indexes<Self>>(
         &self,
         word: W,
@@ -175,6 +172,8 @@ pub trait Deterministic: TransitionSystem {
         )
     }
 
+    /// Returns an iterator yielding the colors of states which are visited infinitely often when running the given `word`
+    /// on the transition system, starting from the initial state. If the run is unsuccessful, `None` is returned.
     fn recurrent_state_colors<W: OmegaWord<SymbolOf<Self>>>(
         &self,
         word: W,
@@ -185,6 +184,8 @@ pub trait Deterministic: TransitionSystem {
         self.recurrent_state_colors_from(word, self.initial())
     }
 
+    /// Gives an iterator that emits the colors of edges which are taken infinitely often when running the given `word`
+    /// on the transition system, starting from the initial state. If the run is unsuccessful, `None` is returned.
     fn recurrent_edge_colors_from<W, Idx>(
         &self,
         word: W,
@@ -199,6 +200,8 @@ pub trait Deterministic: TransitionSystem {
             .map(|p| p.into_recurrent_edge_colors())
     }
 
+    /// Gives an iterator that emits the colors of edges which are taken infinitely often when running the given `word`
+    /// on the transition system, starting from the initial state. If the run is unsuccessful, `None` is returned.
     fn recurrent_edge_colors<W>(&self, word: W) -> Option<impl Iterator<Item = Self::EdgeColor>>
     where
         W: OmegaWord<SymbolOf<Self>>,
@@ -207,6 +210,9 @@ pub trait Deterministic: TransitionSystem {
         self.recurrent_edge_colors_from(word, self.initial())
     }
 
+    /// Returns a [`Vec`] containing the state indices that are visited when running the given `word`
+    /// on the transition system, starting from the initial state. This may include states that are
+    /// visited only finitely often. If the run is unsuccessful, `None` is returned.
     // Todo: once RTTIT is stabilized (1.72), we should return an iterator.
     fn visited_state_sequence_from<W, Idx>(
         &self,
@@ -222,6 +228,9 @@ pub trait Deterministic: TransitionSystem {
             .map(|p| p.state_sequence().collect())
     }
 
+    /// Returns a [`Vec`] containing the state indices that are visited when running the given `word`
+    /// on the transition system, starting from the initial state. This may include states that are
+    /// visited only finitely often. If the run is unsuccessful, `None` is returned.
     fn visited_state_sequence<W>(&self, word: W) -> Option<Vec<Self::StateIndex>>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -230,6 +239,9 @@ pub trait Deterministic: TransitionSystem {
         self.visited_state_sequence_from(word, self.initial())
     }
 
+    /// Returns a [`Vec`] containing the state colors that are visited when running the given `word`
+    /// on the transition system, starting from the initial state. This may include states that are
+    /// visited only finitely often. If the run is unsuccessful, `None` is returned.
     fn visited_state_colors_from<W, Idx>(
         &self,
         word: W,
@@ -244,6 +256,9 @@ pub trait Deterministic: TransitionSystem {
             .map(|p| p.state_colors().cloned().collect())
     }
 
+    /// Returns a [`Vec`] containing the state colors that are visited when running the given `word`
+    /// on the transition system, starting from the initial state. This may include states that are
+    /// visited only finitely often. If the run is unsuccessful, `None` is returned.
     fn visited_state_colors<W>(&self, word: W) -> Option<Vec<Self::StateColor>>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -252,6 +267,9 @@ pub trait Deterministic: TransitionSystem {
         self.visited_state_colors_from(word, self.initial())
     }
 
+    /// Returns a [`Vec`] containing the edge colors that are visited when running the given `word`
+    /// on the transition system, starting from the initial state. This may include edges that are
+    /// visited only finitely often. If the run is unsuccessful, `None` is returned.
     fn visited_edge_colors_from<W, Idx>(&self, word: W, origin: Idx) -> Option<Vec<Self::EdgeColor>>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -262,6 +280,9 @@ pub trait Deterministic: TransitionSystem {
             .map(|p| p.edge_colors().cloned().collect())
     }
 
+    /// Returns a [`Vec`] containing the edge colors that are visited when running the given `word`
+    /// on the transition system, starting from the initial state. This may include edges that are
+    /// visited only finitely often. If the run is unsuccessful, `None` is returned.
     fn visited_edge_colors<W>(&self, word: W) -> Option<Vec<Self::EdgeColor>>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -270,6 +291,8 @@ pub trait Deterministic: TransitionSystem {
         self.visited_edge_colors_from(word, self.initial())
     }
 
+    /// Returns the color of the last edge that is taken when running the given `word` on the transition system,
+    /// starting from the state indexed by `origin`. If the run is unsuccessful, `None` is returned.
     fn last_edge_color_from<W, Idx>(&self, word: W, origin: Idx) -> Option<Self::EdgeColor>
     where
         Idx: Indexes<Self>,
@@ -280,6 +303,8 @@ pub trait Deterministic: TransitionSystem {
             .and_then(|p| p.last_transition_color().cloned())
     }
 
+    /// Returns the color of the last edge that is taken when running the given `word` on the transition system,
+    /// starting from the initial state. If the run is unsuccessful, `None` is returned.
     fn last_edge_color<W>(&self, word: W) -> Option<Self::EdgeColor>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -393,6 +418,8 @@ pub trait Deterministic: TransitionSystem {
             .to_string()
     }
 
+    /// Returns the color of the state that is reached when running `word` from the state indexed by `from`.
+    /// If the run is unsuccessful, `None` is returned.
     fn reached_state_color_from<W, Idx>(&self, word: W, from: Idx) -> Option<Self::StateColor>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -403,6 +430,8 @@ pub trait Deterministic: TransitionSystem {
             .map(|p| p.reached_state_color())
     }
 
+    /// Returns the color of the state that is reached when running `word` from the initial state. If the run
+    /// is unsuccessful, `None` is returned.
     fn reached_state_color<W>(&self, word: W) -> Option<Self::StateColor>
     where
         W: FiniteWord<SymbolOf<Self>>,
@@ -434,6 +463,8 @@ pub trait Deterministic: TransitionSystem {
         self.finite_run_from(word, origin).ok().map(|p| p.reached())
     }
 
+    /// Builds a new [`RightCongruence`] from `self`, which is like viewing only the right congruence underlying
+    /// `self`. This procedure erases the state and edge colors.
     fn collect_right_congruence_bare(&self) -> RightCongruence<Self::Alphabet>
     where
         Self: Pointed,
@@ -441,6 +472,8 @@ pub trait Deterministic: TransitionSystem {
         RightCongruence::from_ts(self.erase_state_colors().erase_edge_colors())
     }
 
+    /// Builds a new [`RightCongruence`] from `self`, which is like viewing only the right congruence underlying
+    /// `self`. This procedure keeps the state and edge colors.
     fn collect_right_congruence(
         &self,
     ) -> RightCongruence<Self::Alphabet, Self::StateColor, Self::EdgeColor>
@@ -479,6 +512,9 @@ pub trait Deterministic: TransitionSystem {
         ts
     }
 
+    /// Collects `self` into a new transition system. This procedure also completes the collected transition
+    /// system with a sink (a state that cannot be left) and for each state of the ts that does not have an
+    /// outgoing transition on some symbol, a new transition into the sink is added.
     fn collect_complete_with_initial(
         &self,
         sink_color: Self::StateColor,
@@ -487,7 +523,6 @@ pub trait Deterministic: TransitionSystem {
     where
         Self: Pointed,
         Self::Alphabet: IndexedAlphabet,
-        Self::StateColor: Default,
     {
         let mut out: Initialized<DTS<_, _, _>> = self.collect_with_initial();
         out.complete_with_colors(sink_color, edge_color);
@@ -528,11 +563,13 @@ pub trait Deterministic: TransitionSystem {
         ts
     }
 
+    /// Returns true if `self` is accessible, meaning every state is reachable from the initial state.
+    /// This is done by counting whether the number of minimal representatives matches the number of states.
     fn is_accessible(&self) -> bool
     where
         Self: Pointed,
     {
-        self.size() == self.trim_collect().size()
+        self.size() == self.minimal_representatives().count()
     }
 
     /// Collects into a transition system of type `Ts`, but only considers states that
@@ -564,6 +601,7 @@ pub trait Deterministic: TransitionSystem {
         ts.with_initial(*map.get(&self.initial()).unwrap())
     }
 
+    /// Builds a new transition system from `self` while maintaining the initial state.
     fn collect_with_initial(
         self,
     ) -> Initialized<DTS<Self::Alphabet, Self::StateColor, Self::EdgeColor>>
@@ -574,7 +612,11 @@ pub trait Deterministic: TransitionSystem {
     }
 
     /// Collects `self` into a new transition system of type `Ts` with the same alphabet, state indices
-    /// and edge colors.
+    /// and edge colors. **This does not consider the initial state.**
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use `trim_collect` or `collect_with_initial` instead"
+    )]
     fn collect<
         Ts: TransitionSystem<
                 StateColor = Self::StateColor,

--- a/automata/src/ts/dot.rs
+++ b/automata/src/ts/dot.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::fmt::{Debug, Display, Write};
 
 use itertools::Itertools;

--- a/automata/src/ts/dot.rs
+++ b/automata/src/ts/dot.rs
@@ -88,7 +88,7 @@ pub trait Dottable: TransitionSystem {
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = DotTransitionAttribute> {
         []
     }
@@ -172,9 +172,14 @@ pub trait Dottable: TransitionSystem {
         }
     }
 
-    /// First creates a rendered PNG using [`Self::render_tempfile()`], after which the rendered
-    /// image is displayed using a locally installed image viewer (`eog` on linux, `qlmanage`
-    /// i.e. quicklook on macos and nothing yet on windows).
+    /// First creates a rendered PNG using [`Self::render()`], after which the rendered
+    /// image is displayed via by using a locally installed image viewer.
+    /// This method is only available on the `graphviz` crate feature.
+    ///
+    /// # Image viewer
+    /// On Macos, the Preview app is used, while on Linux and Windows, the image viewer
+    /// can be configured by setting the `IMAGE_VIEWER` environment variable. If it is not set,
+    /// then the display command of ImageMagick will be used.
     #[cfg(feature = "graphviz")]
     fn display_rendered(&self) -> Result<(), std::io::Error> {
         display_png(self.render()?)?;
@@ -193,7 +198,7 @@ impl<A: Alphabet> Dottable for crate::DFA<A> {
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = DotTransitionAttribute> {
         [DotTransitionAttribute::Label(t.expression.show())].into_iter()
     }
@@ -224,7 +229,7 @@ impl<A: Alphabet, Q: Color, C: Color> Dottable for crate::RightCongruence<A, Q, 
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = DotTransitionAttribute> {
         [DotTransitionAttribute::Label(format!(
             "{}|{}",
@@ -267,7 +272,7 @@ impl<M: MooreLike> Dottable for IntoMooreMachine<M> {
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = DotTransitionAttribute> {
         vec![DotTransitionAttribute::Label(format!(
             "{}|{}",
@@ -302,7 +307,7 @@ impl<M: MealyLike> Dottable for IntoMealyMachine<M> {
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = DotTransitionAttribute> {
         vec![DotTransitionAttribute::Label(format!(
             "{}|{}",
@@ -337,7 +342,7 @@ impl<D: DPALike> Dottable for IntoDPA<D> {
 
     fn dot_transition_attributes<'a>(
         &'a self,
-        t: Self::TransitionRef<'a>,
+        t: Self::EdgeRef<'a>,
     ) -> impl IntoIterator<Item = DotTransitionAttribute> {
         vec![DotTransitionAttribute::Label(format!(
             "{}|{}",

--- a/automata/src/ts/dts.rs
+++ b/automata/src/ts/dts.rs
@@ -2,9 +2,13 @@ use crate::prelude::*;
 
 use super::nts::{NTEdge, NTSEdgesFromIter, NTSEdgesTo};
 
+/// A deterministic transition system. This is a thin wrapper around [`NTS`] and is only used to
+/// enforce that the underlying NTS is deterministic.
 #[derive(Clone, Eq, PartialEq)]
 pub struct DTS<A: Alphabet = Simple, Q = NoColor, C = NoColor>(pub(crate) NTS<A, Q, C>);
 
+/// Type alias to create a deterministic transition with the same alphabet, state and edge color
+/// as the given [`TransitionsSystem`] `Ts`.
 pub type CollectDTS<Ts> = DTS<
     <Ts as TransitionSystem>::Alphabet,
     <Ts as TransitionSystem>::StateColor,
@@ -182,6 +186,7 @@ impl<A: Alphabet, Q: Color, C: Color> Sproutable for DTS<A, Q, C> {
 }
 
 impl<A: Alphabet, Q: Color, C: Color> DTS<A, Q, C> {
+    /// Creates an empty [`DTS`] with the given alphabet and capacity for at least `cap` states.
     pub fn with_capacity(alphabet: A, cap: usize) -> Self {
         Self(NTS::with_capacity(alphabet, cap))
     }

--- a/automata/src/ts/dts.rs
+++ b/automata/src/ts/dts.rs
@@ -8,7 +8,7 @@ use super::nts::{NTEdge, NTSEdgesFromIter, NTSEdgesTo};
 pub struct DTS<A: Alphabet = Simple, Q = NoColor, C = NoColor>(pub(crate) NTS<A, Q, C>);
 
 /// Type alias to create a deterministic transition with the same alphabet, state and edge color
-/// as the given [`TransitionsSystem`] `Ts`.
+/// as the given [`Ts`](`crate::prelude::TransitionSystem`).
 pub type CollectDTS<Ts> = DTS<
     <Ts as TransitionSystem>::Alphabet,
     <Ts as TransitionSystem>::StateColor,
@@ -74,7 +74,7 @@ impl<A: Alphabet, Q: Color, C: Color> TransitionSystem for DTS<A, Q, C> {
 
     type EdgeColor = C;
 
-    type TransitionRef<'this> = &'this NTEdge<A::Expression, C>
+    type EdgeRef<'this> = &'this NTEdge<A::Expression, C>
     where
         Self: 'this;
 
@@ -105,25 +105,10 @@ impl<A: Alphabet, Q: Color, C: Color> TransitionSystem for DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Deterministic for DTS<A, Q, C> {
-    fn transition<Idx: Indexes<Self>>(
-        &self,
-        state: Idx,
-        symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
-        let mut it = self
-            .0
-            .edges_from(state.to_index(self)?)?
-            .filter(|e| IsEdge::expression(e).matches(symbol));
-        let out = it.next();
-        //todo: See if this has performance impact
-        assert!(it.next().is_none());
-        out
-    }
-}
+impl<A: Alphabet, Q: Color, C: Color> Deterministic for DTS<A, Q, C> {}
 
 impl<A: Alphabet, Q: Color, C: Color> PredecessorIterable for DTS<A, Q, C> {
-    type PreTransitionRef<'this> = &'this NTEdge<A::Expression, C>
+    type PreEdgeRef<'this> = &'this NTEdge<A::Expression, C>
     where
         Self: 'this;
 

--- a/automata/src/ts/index_ts.rs
+++ b/automata/src/ts/index_ts.rs
@@ -106,12 +106,16 @@ pub struct BTS<A: Alphabet, Q, C: Color, Idx: IndexType = usize> {
     pub(crate) states: Map<Idx, BTState<A, Q, C, Idx>>,
 }
 
+/// Type alias that takes a [`TransitionSystem`] and gives the type of a corresponding [`BTS`], i.e. one
+/// with the same alphabet, edge and state colors.
 pub type IntoBTS<Ts> = BTS<
     <Ts as TransitionSystem>::Alphabet,
     <Ts as TransitionSystem>::StateColor,
     <Ts as TransitionSystem>::EdgeColor,
 >;
 
+/// Type alias for a [`BTS`] with initial states. Given a [`TransitionSystem`] `Ts`, returns a [`BTS`] with the
+/// same alphabet, edge and state colors, wrapped in a [`Initialized`] type.
 pub type IntoInitialBTS<Ts> = Initialized<
     BTS<
         <Ts as TransitionSystem>::Alphabet,

--- a/automata/src/ts/mod.rs
+++ b/automata/src/ts/mod.rs
@@ -54,6 +54,8 @@ pub mod dag;
 
 /// Encapsulates what is necessary for a type to be usable as a state index in a [`TransitionSystem`].
 pub trait IndexType: Copy + std::hash::Hash + std::fmt::Debug + Eq + Ord + Display + Show {
+    /// Gives the first possible index. For an integer type, this should be `0`. For a product type,
+    /// this should be the product of the first indices of the components.
     fn first() -> Self;
 }
 

--- a/automata/src/ts/mod.rs
+++ b/automata/src/ts/mod.rs
@@ -28,8 +28,12 @@ pub use shrinkable::Shrinkable;
 mod deterministic;
 pub use deterministic::Deterministic;
 
-mod nts;
-pub use nts::{NTSBuilder, NTS};
+/// Implements a type of (nondeterministic) transition system based on a vector of state information and a vector of edges.
+pub mod nts;
+pub use nts::NTS;
+
+mod builder;
+pub use builder::TSBuilder;
 
 mod dts;
 pub use dts::{CollectDTS, DTS};

--- a/automata/src/ts/operations/map.rs
+++ b/automata/src/ts/operations/map.rs
@@ -80,7 +80,7 @@ where
     Ts: PredecessorIterable,
     F: Fn(Ts::StateIndex, &ExpressionOf<Ts>, Ts::EdgeColor, Ts::StateIndex) -> D,
 {
-    type PreTransitionRef<'this> = MappedPreEdge<Ts::StateIndex, Ts::PreTransitionRef<'this>, &'this F, Ts::EdgeColor>
+    type PreEdgeRef<'this> = MappedPreEdge<Ts::StateIndex, Ts::PreEdgeRef<'this>, &'this F, Ts::EdgeColor>
     where
         Self: 'this;
 
@@ -178,7 +178,7 @@ where
 
     type EdgeColor = D;
 
-    type TransitionRef<'this> = MappedEdge<Ts::StateIndex, Ts::TransitionRef<'this>, &'this F, Ts::EdgeColor>
+    type EdgeRef<'this> = MappedEdge<Ts::StateIndex, Ts::EdgeRef<'this>, &'this F, Ts::EdgeColor>
     where
         Self: 'this;
 

--- a/automata/src/ts/operations/map.rs
+++ b/automata/src/ts/operations/map.rs
@@ -125,6 +125,7 @@ pub struct MappedEdge<Idx, T, F, C> {
 }
 
 impl<Idx, T, F, C> MappedEdge<Idx, T, F, C> {
+    /// Create a new mapped edge instance.
     pub fn new(transition: T, from: Idx, f: F) -> Self {
         Self {
             transition,

--- a/automata/src/ts/operations/product.rs
+++ b/automata/src/ts/operations/product.rs
@@ -173,9 +173,9 @@ where
 pub struct ProductEdgesFrom<'a, L: TransitionSystem, R: TransitionSystem> {
     left: &'a L,
     right: &'a R,
-    cur: Option<L::TransitionRef<'a>>,
+    cur: Option<L::EdgeRef<'a>>,
     it: L::EdgesFromIter<'a>,
-    right_edges: Vec<R::TransitionRef<'a>>,
+    right_edges: Vec<R::EdgeRef<'a>>,
     position: usize,
 }
 
@@ -294,9 +294,9 @@ impl<'a, LI, RI, E, LC, RC> ProductPreTransition<'a, LI, RI, E, LC, RC> {
 pub struct ProductEdgesTo<'a, L: PredecessorIterable, R: PredecessorIterable> {
     left: &'a L,
     right: &'a R,
-    cur: Option<L::PreTransitionRef<'a>>,
+    cur: Option<L::PreEdgeRef<'a>>,
     it: L::EdgesToIter<'a>,
-    right_edges: Vec<R::PreTransitionRef<'a>>,
+    right_edges: Vec<R::PreEdgeRef<'a>>,
     position: usize,
 }
 

--- a/automata/src/ts/operations/product.rs
+++ b/automata/src/ts/operations/product.rs
@@ -380,9 +380,9 @@ mod tests {
             .with_transitions([(0, 'a', 0, 0)])
             .deterministic()
             .with_initial(0);
-        assert!((&l).ts_product(&l).reached("b").is_some());
+        assert!((&l).ts_product(&l).reached_state_index("b").is_some());
         let prod = l.ts_product(r);
-        assert!(prod.reached("a").is_some());
-        assert!(prod.reached("b").is_none());
+        assert!(prod.reached_state_index("a").is_some());
+        assert!(prod.reached_state_index("b").is_none());
     }
 }

--- a/automata/src/ts/operations/restricted.rs
+++ b/automata/src/ts/operations/restricted.rs
@@ -132,7 +132,7 @@ impl<'a, Ts: TransitionSystem + 'a, F> Iterator for RestrictedEdgesFromIter<'a, 
 where
     F: StateIndexFilter<Ts::StateIndex>,
 {
-    type Item = Ts::TransitionRef<'a>;
+    type Item = Ts::EdgeRef<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         self.it
             .by_ref()
@@ -151,7 +151,7 @@ impl<'a, Ts: PredecessorIterable + 'a, F> Iterator for RestrictedEdgesToIter<'a,
 where
     F: StateIndexFilter<Ts::StateIndex>,
 {
-    type Item = Ts::PreTransitionRef<'a>;
+    type Item = Ts::PreEdgeRef<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         self.it
             .by_ref()
@@ -188,7 +188,7 @@ impl<D: TransitionSystem> TransitionSystem for ColorRestricted<D> {
 
     type EdgeColor = D::EdgeColor;
 
-    type TransitionRef<'this> = D::TransitionRef<'this>
+    type EdgeRef<'this> = D::EdgeRef<'this>
     where
         Self: 'this;
 
@@ -225,7 +225,7 @@ impl<D: TransitionSystem> TransitionSystem for ColorRestricted<D> {
 }
 
 impl<D: PredecessorIterable<EdgeColor = usize>> PredecessorIterable for ColorRestricted<D> {
-    type PreTransitionRef<'this> = D::PreTransitionRef<'this>
+    type PreEdgeRef<'this> = D::PreEdgeRef<'this>
     where
         Self: 'this;
 
@@ -243,7 +243,7 @@ impl<D: DPALike> Deterministic for ColorRestricted<D> {
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         self.ts()
             .transition(state.to_index(self)?, symbol)
             .and_then(|t| {
@@ -266,7 +266,7 @@ pub struct ColorRestrictedEdgesFrom<'a, D: TransitionSystem> {
 }
 
 impl<'a, D: TransitionSystem> Iterator for ColorRestrictedEdgesFrom<'a, D> {
-    type Item = D::TransitionRef<'a>;
+    type Item = D::EdgeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.it
@@ -284,7 +284,7 @@ pub struct ColorRestrictedEdgesTo<'a, D: PredecessorIterable> {
 }
 
 impl<'a, D: PredecessorIterable> Iterator for ColorRestrictedEdgesTo<'a, D> {
-    type Item = D::PreTransitionRef<'a>;
+    type Item = D::PreEdgeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.it

--- a/automata/src/ts/operations/restricted.rs
+++ b/automata/src/ts/operations/restricted.rs
@@ -166,6 +166,8 @@ impl<'a, Ts: PredecessorIterable + 'a, F> RestrictedEdgesToIter<'a, Ts, F> {
     }
 }
 
+/// Takes a transition system and restricts the the possible edge colors. For this, we assume that the colors
+/// can be ordered and we are given a minimal and maximal allowed color.
 #[derive(Clone, Debug)]
 pub struct ColorRestricted<D: TransitionSystem> {
     ts: D,
@@ -254,6 +256,8 @@ impl<D: DPALike> Deterministic for ColorRestricted<D> {
     }
 }
 
+/// Adapted iterator giving the edges from a state in a transition system that are restricted by a
+/// color range. See [`ColorRestricted`] for more information.
 pub struct ColorRestrictedEdgesFrom<'a, D: TransitionSystem> {
     _phantom: PhantomData<&'a D>,
     it: D::EdgesFromIter<'a>,
@@ -270,6 +274,8 @@ impl<'a, D: TransitionSystem> Iterator for ColorRestrictedEdgesFrom<'a, D> {
     }
 }
 
+/// Adapted iterator giving the edges to a state in a transition system that are restricted by a
+/// color range. See [`ColorRestricted`] for more information.
 pub struct ColorRestrictedEdgesTo<'a, D: PredecessorIterable> {
     _phantom: PhantomData<&'a D>,
     it: D::EdgesToIter<'a>,
@@ -287,9 +293,12 @@ impl<'a, D: PredecessorIterable> Iterator for ColorRestrictedEdgesTo<'a, D> {
 }
 
 impl<D: TransitionSystem> ColorRestricted<D> {
+    /// Returns a reference to the underlying transition system.
     pub fn ts(&self) -> &D {
         &self.ts
     }
+    /// Creates a new instance for a given transition system and a color range (as specified by the `min` and `max`
+    /// allowed color)
     pub fn new(ts: D, min: D::EdgeColor, max: D::EdgeColor) -> Self {
         Self { ts, min, max }
     }

--- a/automata/src/ts/operations/reverse.rs
+++ b/automata/src/ts/operations/reverse.rs
@@ -37,11 +37,11 @@ where
 
     type EdgeColor = Ts::EdgeColor;
 
-    type TransitionRef<'this> = Reversed<Ts::PreTransitionRef<'this>>
+    type EdgeRef<'this> = Reversed<Ts::PreEdgeRef<'this>>
     where
         Self: 'this;
 
-    type EdgesFromIter<'this> = std::iter::Map<Ts::EdgesToIter<'this>, fn(Ts::PreTransitionRef<'this>) -> Reversed<Ts::PreTransitionRef<'this>>>
+    type EdgesFromIter<'this> = std::iter::Map<Ts::EdgesToIter<'this>, fn(Ts::PreEdgeRef<'this>) -> Reversed<Ts::PreEdgeRef<'this>>>
     where
         Self: 'this;
 
@@ -73,11 +73,11 @@ impl<Ts> PredecessorIterable for Reversed<Ts>
 where
     Ts: TransitionSystem + PredecessorIterable,
 {
-    type PreTransitionRef<'this> = Reversed<Ts::TransitionRef<'this>>
+    type PreEdgeRef<'this> = Reversed<Ts::EdgeRef<'this>>
     where
         Self: 'this;
 
-    type EdgesToIter<'this> = std::iter::Map<Ts::EdgesFromIter<'this>, fn(Ts::TransitionRef<'this>) -> Reversed<Ts::TransitionRef<'this>>>
+    type EdgesToIter<'this> = std::iter::Map<Ts::EdgesFromIter<'this>, fn(Ts::EdgeRef<'this>) -> Reversed<Ts::EdgeRef<'this>>>
     where
         Self: 'this;
 

--- a/automata/src/ts/operations/reverse.rs
+++ b/automata/src/ts/operations/reverse.rs
@@ -3,6 +3,7 @@ use crate::{
     TransitionSystem,
 };
 
+/// Reverses the direction of all transitions in a given [`TransitionSystem`].
 #[derive(Clone, Debug)]
 pub struct Reversed<Ts>(pub Ts);
 

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -67,7 +67,7 @@ impl<Ts: TransitionSystem> Deterministic for SubsetConstruction<Ts> {
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         let source = state.to_index(self)?;
         let (colorset, stateset): (Vec<Ts::EdgeColor>, StateSet<Ts>) = self
             .states
@@ -117,7 +117,7 @@ impl<Ts: TransitionSystem> TransitionSystem for SubsetConstruction<Ts> {
 
     type EdgeColor = Vec<Ts::EdgeColor>;
 
-    type TransitionRef<'this> = TransitionOwnedColor<'this, ExpressionOf<Ts>, usize, Self::EdgeColor>
+    type EdgeRef<'this> = TransitionOwnedColor<'this, ExpressionOf<Ts>, usize, Self::EdgeColor>
     where
         Self: 'this;
 

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -53,6 +53,9 @@ impl<Ts: TransitionSystem> StateSet<Ts> {
     }
 }
 
+/// Represents the subset construction applied to a transition system. This is a deterministic
+/// transition system, which resolves the non-determinism by operating on sets of states.
+#[derive(Clone)]
 pub struct SubsetConstruction<Ts: TransitionSystem> {
     ts: Ts,
     states: RefCell<Vec<StateSet<Ts>>>,
@@ -176,6 +179,7 @@ impl<Ts: TransitionSystem> Debug for SubsetConstruction<Ts> {
 }
 
 impl<Ts: TransitionSystem> SubsetConstruction<Ts> {
+    /// Creates a new subset construction from the given transition system starting from the given index.
     pub fn new_from(ts: Ts, idx: Ts::StateIndex) -> Self {
         Self {
             expressions: ts.alphabet().expression_map(),
@@ -184,6 +188,8 @@ impl<Ts: TransitionSystem> SubsetConstruction<Ts> {
         }
     }
 
+    /// Creates a new subset construction from the given transition system starting from the given
+    /// indices.
     pub fn new<I: IntoIterator<Item = Ts::StateIndex>>(ts: Ts, iter: I) -> Self {
         Self {
             expressions: ts.alphabet().expression_map(),

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{
     prelude::*,
-    ts::{reachable::ReachableStateIndices, transition_system::TransitionOwned},
+    ts::{reachable::ReachableStateIndices, transition_system::TransitionOwnedColor},
     Set,
 };
 
@@ -85,7 +85,7 @@ impl<Ts: TransitionSystem> Deterministic for SubsetConstruction<Ts> {
             })
             .unzip();
         if let Some(pos) = self.states.borrow().iter().position(|s| stateset.eq(s)) {
-            return Some(TransitionOwned::new(
+            return Some(TransitionOwnedColor::new(
                 source,
                 self.expressions.get(&symbol).unwrap(),
                 colorset,
@@ -94,7 +94,7 @@ impl<Ts: TransitionSystem> Deterministic for SubsetConstruction<Ts> {
         }
 
         self.states.borrow_mut().push(stateset);
-        Some(TransitionOwned::new(
+        Some(TransitionOwnedColor::new(
             source,
             self.expressions.get(&symbol).unwrap(),
             colorset,
@@ -117,7 +117,7 @@ impl<Ts: TransitionSystem> TransitionSystem for SubsetConstruction<Ts> {
 
     type EdgeColor = Vec<Ts::EdgeColor>;
 
-    type TransitionRef<'this> = TransitionOwned<'this, ExpressionOf<Ts>, usize, Self::EdgeColor>
+    type TransitionRef<'this> = TransitionOwnedColor<'this, ExpressionOf<Ts>, usize, Self::EdgeColor>
     where
         Self: 'this;
 

--- a/automata/src/ts/path.rs
+++ b/automata/src/ts/path.rs
@@ -12,8 +12,10 @@ use super::{
 /// to create a path through some transition system, modify the transition system and then extend the previously
 /// created path in the modified transiton system.
 ///
-/// A path consists of an `origin`, which is simply the index of the state where the path starts. It stores
-/// a sequence of transitions and the colors of the states it visits.
+/// We represent a path as a sequence of transitions, where each transition is a tuple of the source state,
+/// the symbol that is taken and the color of the transition. The path also stores the colors of all states
+/// that are visited by the path. Finally, we store the index of the state that is reached by the path separately.
+/// This is done to allow for efficient extension of the path. Also we know that there can be no empty paths.
 #[derive(Clone, PartialEq, Hash)]
 pub struct Path<A: Alphabet, Idx, Q, C> {
     end: Idx,
@@ -21,6 +23,7 @@ pub struct Path<A: Alphabet, Idx, Q, C> {
     transitions: Vec<(Idx, A::Symbol, C)>,
 }
 
+/// Type alias that given a [`TransitionSystem`] `D` creates a [`Path`] in `D`.
 pub type PathIn<D> = Path<
     <D as TransitionSystem>::Alphabet,
     <D as TransitionSystem>::StateIndex,
@@ -29,6 +32,8 @@ pub type PathIn<D> = Path<
 >;
 
 impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
+    /// Builds a new path from its parts, which are the index of the state it ends in, the sequence of
+    /// state colors and the setquence of transitions.
     pub fn from_parts(
         end: Idx,
         state_colors: Vec<Q>,
@@ -46,6 +51,7 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
         self.end
     }
 
+    /// Gives the origin of the path, which is the index of the state the path starts in.
     pub fn origin(&self) -> Idx {
         if !self.transitions.is_empty() {
             self.transitions[0].0
@@ -84,6 +90,7 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
         self.state_colors.iter()
     }
 
+    /// Consumes `self` and returns an iterator over all colors of the states visited by the path. May contain ducplicates.
     pub fn into_state_colors(self) -> impl Iterator<Item = Q> {
         self.state_colors.into_iter()
     }
@@ -107,6 +114,7 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
         }
     }
 
+    /// Creates a new empty path that starts in the given `state` and has the given `capacity`.
     pub fn empty_in_with_capacity<D>(ts: D, state: Idx, capacity: usize) -> Self
     where
         D: Deterministic<StateColor = Q, EdgeColor = C, StateIndex = Idx, Alphabet = A>,
@@ -161,6 +169,7 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
             .chain(std::iter::once(self.end))
     }
 
+    /// Consumes `self` and returns an iterator over the indices of the states visited by the path. May contain duplicates.
     pub fn into_state_sequence(self) -> impl Iterator<Item = Idx> {
         self.transitions
             .into_iter()
@@ -173,6 +182,7 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
         self.transitions.iter().map(|(source, sym, c)| c)
     }
 
+    /// Consumes `self` and returns an iterator over all colors which appear on an edge taken by the path. May contain duplicates.
     pub fn into_edge_colors(self) -> impl Iterator<Item = C> {
         self.transitions.into_iter().map(|(p, a, c)| c)
     }
@@ -217,6 +227,7 @@ pub struct Lasso<A: Alphabet, Idx, Q, C> {
     cycle: Path<A, Idx, Q, C>,
 }
 
+/// Type alias that given a [`TransitionSystem`] `D` creates a [`Lasso`] in `D`.
 pub type LassoIn<D> = Lasso<
     <D as TransitionSystem>::Alphabet,
     <D as TransitionSystem>::StateIndex,
@@ -230,26 +241,34 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Lasso<A, Idx, Q, C> {
         Self { base, cycle }
     }
 
+    /// Gives an iterator over the state indices that appear in the cycle of the lasso. These
+    /// are precisely the states that appear infinitely often. May contain duplicates.
     pub fn recurrent_state_indices(&self) -> impl Iterator<Item = Idx> + '_ {
         self.cycle.state_sequence()
     }
 
+    /// Gives the colors of states along the cycle, so colors that appear infinitely often. May contain duplicates.
     pub fn recurrent_state_colors(&self) -> impl Iterator<Item = &Q> {
         self.cycle.state_colors()
     }
 
+    /// Gives the colors of edges along the loop, so colors that appear infinitely often. May contain duplicates.
     pub fn recurrent_edge_colors(&self) -> impl Iterator<Item = &C> {
         self.cycle.edge_colors()
     }
 
+    /// Consumes `self` and gives an iterator over the state indices that appear in the cycle of the lasso. These
+    /// are precisely the states that appear infinitely often. May contain duplicates.
     pub fn into_recurrent_state_indices(self) -> impl Iterator<Item = Idx> {
         self.cycle.into_state_sequence()
     }
 
+    /// Consumes `self` and gives the colors of states along the cycle, so colors that appear infinitely often. May contain duplicates.
     pub fn into_recurrent_state_colors(self) -> impl Iterator<Item = Q> {
         self.cycle.into_state_colors()
     }
 
+    /// Consumes `self` and gives the colors of edges along the loop, so colors that appear infinitely often. May contain duplicates.
     pub fn into_recurrent_edge_colors(self) -> impl Iterator<Item = C> {
         self.cycle.into_edge_colors()
     }

--- a/automata/src/ts/path.rs
+++ b/automata/src/ts/path.rs
@@ -133,11 +133,7 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
 
     /// Attempts to extend the path in the given `ts` by the given `symbol`. If the path can be extended,
     /// the transition is returned. Otherwise, `None` is returned.
-    pub fn extend_in<'a, D>(
-        &mut self,
-        ts: &'a D,
-        symbol: SymbolOf<D>,
-    ) -> Option<D::TransitionRef<'a>>
+    pub fn extend_in<'a, D>(&mut self, ts: &'a D, symbol: SymbolOf<D>) -> Option<D::EdgeRef<'a>>
     where
         D: Deterministic<StateColor = Q, EdgeColor = C, StateIndex = Idx, Alphabet = A>,
     {

--- a/automata/src/ts/predecessors.rs
+++ b/automata/src/ts/predecessors.rs
@@ -33,6 +33,8 @@ pub trait PredecessorIterable: TransitionSystem {
     /// Returns an iterator over the predecessors of the given `state`. Returns `None` if the state does not exist.
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>>;
 
+    /// Reverses the directions of all transitions in the transition system. This consumes the transition system.
+    /// See also [`Reversed`].
     fn reversed(self) -> Reversed<Self> {
         Reversed(self)
     }
@@ -125,6 +127,8 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> PredecessorIterable for BT
     }
 }
 
+/// Iterator over the predecessors of a state in a BTS.
+#[derive(Clone)]
 pub struct BTSPredecessors<'a, A: Alphabet, C: Color, Idx: IndexType> {
     it: std::collections::hash_set::Iter<'a, (Idx, A::Expression, C)>,
     state: Idx,
@@ -141,6 +145,7 @@ impl<'a, A: Alphabet, C: Color, Idx: IndexType> Iterator for BTSPredecessors<'a,
 }
 
 impl<'a, A: Alphabet, C: Color, Idx: IndexType> BTSPredecessors<'a, A, C, Idx> {
+    /// Creates a new instance from an iterator and a state.
     pub fn new(
         it: std::collections::hash_set::Iter<'a, (Idx, A::Expression, C)>,
         state: Idx,

--- a/automata/src/ts/predecessors.rs
+++ b/automata/src/ts/predecessors.rs
@@ -16,17 +16,12 @@ use super::{
 /// Implementors of this trait are [`TransitionSystem`]s which allow iterating over the predecessors of a state.
 pub trait PredecessorIterable: TransitionSystem {
     /// The type of pre-transition that the iterator yields.
-    type PreTransitionRef<'this>: IsEdge<
-        'this,
-        ExpressionOf<Self>,
-        Self::StateIndex,
-        EdgeColor<Self>,
-    >
+    type PreEdgeRef<'this>: IsEdge<'this, ExpressionOf<Self>, Self::StateIndex, EdgeColor<Self>>
     where
         Self: 'this;
 
     /// The type of iterator over the predecessors of a state.
-    type EdgesToIter<'this>: Iterator<Item = Self::PreTransitionRef<'this>>
+    type EdgesToIter<'this>: Iterator<Item = Self::PreEdgeRef<'this>>
     where
         Self: 'this;
 
@@ -45,7 +40,7 @@ where
     Ts: PredecessorIterable,
     F: StateIndexFilter<Ts::StateIndex>,
 {
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
     type EdgesToIter<'this> = RestrictedEdgesToIter<'this, Ts, F> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         Some(RestrictedEdgesToIter::new(
@@ -56,14 +51,14 @@ where
 }
 
 impl<Ts: PredecessorIterable> PredecessorIterable for &Ts {
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
     type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         Ts::predecessors(self, state)
     }
 }
 impl<Ts: PredecessorIterable> PredecessorIterable for &mut Ts {
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
     type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         Ts::predecessors(self, state)
@@ -76,7 +71,7 @@ where
     Ts: PredecessorIterable,
     F: Fn(Ts::EdgeColor) -> D,
 {
-    type PreTransitionRef<'this> = MappedPreTransition<Ts::PreTransitionRef<'this>, &'this F, Ts::EdgeColor> where Self: 'this;
+    type PreEdgeRef<'this> = MappedPreTransition<Ts::PreEdgeRef<'this>, &'this F, Ts::EdgeColor> where Self: 'this;
     type EdgesToIter<'this> = MappedTransitionsToIter<'this, Ts::EdgesToIter<'this>, F, Ts::EdgeColor> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         Some(MappedTransitionsToIter::new(
@@ -93,7 +88,7 @@ where
     F: Fn(Ts::StateColor) -> D,
 {
     type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         self.ts().predecessors(state)
     }
@@ -107,7 +102,7 @@ where
     L::StateColor: Clone,
     R::StateColor: Clone,
 {
-    type PreTransitionRef<'this> = ProductPreTransition<'this, L::StateIndex, R::StateIndex, ExpressionOf<L>, L::EdgeColor, R::EdgeColor> where Self: 'this;
+    type PreEdgeRef<'this> = ProductPreTransition<'this, L::StateIndex, R::StateIndex, ExpressionOf<L>, L::EdgeColor, R::EdgeColor> where Self: 'this;
     type EdgesToIter<'this> = ProductEdgesTo<'this, L, R> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         ProductEdgesTo::new(&self.0, &self.1, state)
@@ -115,7 +110,7 @@ where
 }
 
 impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> PredecessorIterable for BTS<A, Q, C, Idx> {
-    type PreTransitionRef<'this> = EdgeReference<'this, A::Expression, Idx, C> where Self: 'this;
+    type PreEdgeRef<'this> = EdgeReference<'this, A::Expression, Idx, C> where Self: 'this;
     type EdgesToIter<'this> = BTSPredecessors<'this, A, C, Idx>
     where
         Self: 'this;
@@ -155,7 +150,7 @@ impl<'a, A: Alphabet, C: Color, Idx: IndexType> BTSPredecessors<'a, A, C, Idx> {
 }
 
 impl<A: Alphabet> PredecessorIterable for RightCongruence<A> {
-    type PreTransitionRef<'this> = &'this NTEdge<A::Expression, ()>
+    type PreEdgeRef<'this> = &'this NTEdge<A::Expression, ()>
     where
         Self: 'this;
 
@@ -168,7 +163,7 @@ impl<A: Alphabet> PredecessorIterable for RightCongruence<A> {
 }
 
 impl<Ts: PredecessorIterable> PredecessorIterable for Initialized<Ts> {
-    type PreTransitionRef<'this> = Ts::PreTransitionRef<'this> where Self: 'this;
+    type PreEdgeRef<'this> = Ts::PreEdgeRef<'this> where Self: 'this;
     type EdgesToIter<'this> = Ts::EdgesToIter<'this> where Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
         self.ts().predecessors(state)

--- a/automata/src/ts/quotient.rs
+++ b/automata/src/ts/quotient.rs
@@ -187,7 +187,7 @@ impl<Ts: Deterministic> TransitionSystem for Quotient<Ts> {
 
     type EdgeColor = Vec<Ts::EdgeColor>;
 
-    type TransitionRef<'this> = QuotientTransition<'this, usize, ExpressionOf<Self>, Ts::EdgeColor>
+    type EdgeRef<'this> = QuotientTransition<'this, usize, ExpressionOf<Self>, Ts::EdgeColor>
     where
         Self: 'this;
 
@@ -230,7 +230,7 @@ impl<D: Deterministic> Deterministic for Quotient<D> {
         &self,
         state: Idx,
         symbol: SymbolOf<Self>,
-    ) -> Option<Self::TransitionRef<'_>> {
+    ) -> Option<Self::EdgeRef<'_>> {
         let origin = state.to_index(self)?;
         let (states, colors): (Set<_>, Vec<_>) = self
             .class_iter_by_id(origin)?

--- a/automata/src/ts/quotient.rs
+++ b/automata/src/ts/quotient.rs
@@ -32,14 +32,18 @@ impl<Ts: Deterministic + Pointed> Pointed for Quotient<Ts> {
 }
 
 impl<Ts: TransitionSystem> Quotient<Ts> {
+    /// Returns a reference to the [`Partition`] underlying the quotient.
     pub fn partition(&self) -> &Partition<Ts::StateIndex> {
         &self.partition
     }
 
+    /// Gives a reference to the underlying transition system.
     pub fn ts(&self) -> &Ts {
         &self.ts
     }
 
+    /// Indexes into the underlying partition and tries to get a representative for the indexed class.
+    /// Panics if the class does not exist or is empty.
     pub fn unwrap_class_representative(&self, id: usize) -> Ts::StateIndex {
         *self
             .partition
@@ -85,6 +89,8 @@ impl<Ts: TransitionSystem> Quotient<Ts> {
         true
     }
 
+    /// Extracts the underlying right congruence by erasing the state and edge colors and then collecting
+    /// into a [`RightCongruence`].
     pub fn underlying_right_congruence(self, ts: &Ts) -> RightCongruence<Ts::Alphabet>
     where
         Ts: Deterministic + Pointed,

--- a/automata/src/ts/reachable.rs
+++ b/automata/src/ts/reachable.rs
@@ -4,6 +4,8 @@ use crate::{prelude::Expression, ts::StateColor, Alphabet, Set, TransitionSystem
 
 use super::{transition_system::IsEdge, Deterministic, SymbolOf};
 
+/// Type alias for a minimal representative of a state which is its length-lexicographically minimal
+/// access sequence and its state index.
 pub type MinimalRepresentative<Ts> = (Vec<SymbolOf<Ts>>, <Ts as TransitionSystem>::StateIndex);
 
 /// Struct that can return the minimal representatives of a transition system. A minimal representative

--- a/automata/src/ts/shrinkable.rs
+++ b/automata/src/ts/shrinkable.rs
@@ -9,11 +9,11 @@ pub trait Shrinkable: TransitionSystem {
     fn remove_state<Idx: Indexes<Self>>(&mut self, state: Idx) -> Option<Self::StateColor>;
 
     /// Removes the first edge from the transition system that originates in `source` and matches the given
-    /// `expression`. The call returns a pair consisting of the color and target of the removed edge.
+    /// `crate::prelude::Expression`. The call returns a pair consisting of the color and target of the removed edge.
     /// If no suitable edge is present, returns `None`.
     ///
-    /// This method expects to identify the edge that should be removed based on its [`Expression`], for
-    /// a method that identifies the edge based on its target, see [`remove_transitions`].
+    /// This method expects to identify the edge that should be removed based on its [`crate::prelude::Expression`], for
+    /// a method that identifies the edge based on its target, see [`Self::remove_transitions`].
     fn remove_edge<Idx: Indexes<Self>>(
         &mut self,
         source: Idx,

--- a/automata/src/ts/shrinkable.rs
+++ b/automata/src/ts/shrinkable.rs
@@ -2,13 +2,27 @@ use crate::{automaton::Initialized, Alphabet, Color, Set, TransitionSystem};
 
 use super::{transition_system::Indexes, ExpressionOf, IndexType, SymbolOf, BTS, DTS, NTS};
 
+/// Encapsulates the ability to remove states, edges, and transitions from a transition system.
 pub trait Shrinkable: TransitionSystem {
+    /// Removes a state from the transition system and returns the color associated with the removed state.
+    /// If the state is not present, returns `None`.
     fn remove_state<Idx: Indexes<Self>>(&mut self, state: Idx) -> Option<Self::StateColor>;
+
+    /// Removes the first edge from the transition system that originates in `source` and matches the given
+    /// `expression`. The call returns a pair consisting of the color and target of the removed edge.
+    /// If no suitable edge is present, returns `None`.
+    ///
+    /// This method expects to identify the edge that should be removed based on its [`Expression`], for
+    /// a method that identifies the edge based on its target, see [`remove_transitions`].
     fn remove_edge<Idx: Indexes<Self>>(
         &mut self,
         source: Idx,
         expression: &ExpressionOf<Self>,
     ) -> Option<(Self::EdgeColor, Self::StateIndex)>;
+
+    /// Removes **all** transitions from the transition system that originate in `source` and match the given
+    /// `symbol`. The call returns a [`Set`] of triples, each consisting of the expression, color, and target of
+    /// the removed transition. If no suitable transitions are present, returns `None`.
     #[allow(clippy::type_complexity)]
     fn remove_transitions<Idx: Indexes<Self>>(
         &mut self,

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -5,14 +5,22 @@ use crate::{prelude::Simple, Alphabet, Pointed, TransitionSystem};
 
 use super::{transition_system::IsEdge, EdgeColor, StateColor};
 
+/// Marker trait for [`Alphabet`]s that can be indexed, i.e. where we can associate each
+/// [`Alphabet::Symbol`] and [`Alphabet::Expression`] with a unique index (a `usize`).
 pub trait IndexedAlphabet: Alphabet {
+    /// Turns the given symbol into an index.
     fn symbol_to_index(&self, sym: Self::Symbol) -> usize;
+    /// Turns the given expression into an index.
     fn expression_to_index(&self, sym: &Self::Expression) -> usize;
+    /// Returns the symbol that corresponds to the given index.
     fn symbol_from_index(&self, index: usize) -> Self::Symbol;
+    /// Returns the expression that corresponds to the given index.
     fn expression_from_index(&self, index: usize) -> Self::Expression;
+    /// Turns the given expression into a symbol.
     fn expression_to_symbol(&self, expression: &Self::Expression) -> Self::Symbol {
         self.symbol_from_index(self.expression_to_index(expression))
     }
+    /// Turns the given symbol into an expression.
     fn symbol_to_expression(&self, symbol: Self::Symbol) -> Self::Expression {
         self.expression_from_index(self.symbol_to_index(symbol))
     }
@@ -45,6 +53,11 @@ pub trait Sproutable: TransitionSystem {
     /// Creates a new instance of `Self` for the given alphabet.
     fn new_for_alphabet(alphabet: Self::Alphabet) -> Self;
 
+    /// Turns the automaton into a complete one, by adding a sink state and adding transitions
+    /// to it from all states that do not have a transition for a given symbol.
+    ///
+    /// The sink state will be colored with `sink_color` and each newly introduced edge will
+    /// be colored with `edge_color`.
     fn complete_with_colors(&mut self, sink_color: Self::StateColor, edge_color: Self::EdgeColor)
     where
         Self::Alphabet: IndexedAlphabet,

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -153,7 +153,7 @@ mod tests {
                 (1, 'a', 0, 0),
             ])
             .deterministic();
-        assert_eq!(partial.reached_from("aaacb", 0), None);
+        assert_eq!(partial.reached_state_index_from("aaacb", 0), None);
         partial.complete_with_colors((), 2);
         println!("{}", partial.build_transition_table(|q, c| format!("{q}")));
         for w in ["abbaccababcab", "bbcca", "cc", "aababbabbabbccbabba"] {

--- a/automata/src/word/concat.rs
+++ b/automata/src/word/concat.rs
@@ -4,6 +4,8 @@ use crate::{length::HasLength, prelude::Symbol, FiniteLength, Length};
 
 use super::{FiniteWord, LinearWord, OmegaWord};
 
+/// Concatenates two words. This operation is really only sensible when the first word
+/// is of finite length.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Concat<X, Y>(pub X, pub Y);
 

--- a/automata/src/word/finite.rs
+++ b/automata/src/word/finite.rs
@@ -99,11 +99,11 @@ pub trait FiniteWord<S>: LinearWord<S> {
     where
         S: Show,
     {
-        let mut it = self.symbols().map(|a| a.show()).peekable();
-        if it.peek().is_none() {
+        let out = self.symbols().map(|a| a.show()).join("");
+        if out.is_empty() {
             "ε".into()
         } else {
-            it.join("")
+            out
         }
     }
 }

--- a/automata/src/word/finite.rs
+++ b/automata/src/word/finite.rs
@@ -7,13 +7,18 @@ use crate::{prelude::Symbol, Show};
 
 use super::{omega::Reduced, Concat, LinearWord, Periodic};
 
+/// A finite word is a [`LinearWord`] that has a finite length.
 pub trait FiniteWord<S>: LinearWord<S> {
+    /// Type for an iterator over the symbols making up the word.
     type Symbols<'this>: Iterator<Item = S>
     where
         Self: 'this;
 
+    /// Returns an iterator over the symbols of the word.
     fn symbols(&self) -> Self::Symbols<'_>;
 
+    /// Appends the given [`LinearWord`] to the end of this word. Note, that the appended
+    /// suffix may be finite or infinite.
     fn append<W: LinearWord<S>>(self, suffix: W) -> Concat<Self, W>
     where
         Self: Sized,
@@ -21,6 +26,8 @@ pub trait FiniteWord<S>: LinearWord<S> {
         Concat(self, suffix)
     }
 
+    /// Checks if the given word is equal to this word. Note, that this operation only makes sense
+    /// when both words are finite.
     fn equals<W: FiniteWord<S>>(&self, other: W) -> bool
     where
         S: Eq,
@@ -28,6 +35,8 @@ pub trait FiniteWord<S>: LinearWord<S> {
         self.len() == other.len() && self.symbols().zip(other.symbols()).all(|(a, b)| a == b)
     }
 
+    /// Prepends the given `prefix` to the beginning of this word. This operation only works if
+    /// the prefix is finite.
     fn prepend<W: FiniteWord<S>>(self, prefix: W) -> Concat<W, Self>
     where
         Self: Sized,
@@ -35,33 +44,57 @@ pub trait FiniteWord<S>: LinearWord<S> {
         Concat(prefix, self)
     }
 
+    /// Collects the symbols making up `self` into a vector.
     fn to_vec(&self) -> Vec<S> {
         self.symbols().collect()
     }
 
+    /// Collects the symbols making up `self` into a [`VecDeque`].
     fn to_deque(&self) -> VecDeque<S> {
         VecDeque::from(self.to_vec())
     }
 
+    /// Builds the [`Periodic`] word that is the omega power of this word, i.e. if
+    /// `self` is the word `u`, then the result is the word `u^ω` = `u u u u ...`.
+    /// Panics if `self` is empty as the operation is not defined in that case.
     fn omega_power(&self) -> Periodic<S>
     where
         S: Symbol,
     {
+        assert!(
+            !self.is_empty(),
+            "Omega iteration of an empty word is undefined!"
+        );
         Periodic::new(self)
     }
 
+    /// Gives the length of the word, i.e. the number of symbols.
     fn len(&self) -> usize {
         self.symbols().count()
     }
 
+    /// Returns the `n`-th symbol of the word from the back.
+    ///
+    /// # Example
+    /// ```
+    /// use automata::prelude::*;
+    /// let word = "abc";
+    ///
+    /// assert_eq!(word.nth_back(0), Some('c'));
+    /// assert_eq!(word.nth_back(1), Some('b'));
+    /// assert_eq!(word.nth_back(2), Some('a'));
+    /// ```
     fn nth_back(&self, pos: usize) -> Option<S> {
         self.nth(self.len() - pos - 1)
     }
 
+    /// Returns `true` if the word is empty, i.e. has no symbols.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Converts the word to a string. This is only possible if the the symbols implement
+    /// the [`Show`] trait.
     fn as_string(&self) -> String
     where
         S: Show,

--- a/automata/src/word/mod.rs
+++ b/automata/src/word/mod.rs
@@ -22,7 +22,7 @@ mod omega;
 pub use omega::{OmegaWord, Periodic, Reduced, ReducedParseError};
 use tracing::subscriber::SetGlobalDefaultError;
 
-use self::subword::Infix;
+pub use self::subword::Infix;
 
 /// A linear word is a word that can be indexed by a `usize`. This is the case for both finite and
 /// infinite words.
@@ -43,9 +43,9 @@ pub trait LinearWord<S>: Hash + Eq {
     ///
     /// # Example
     /// ```
-    /// use automata::word::LinearWord;
-    /// let word = "abcde";
-    /// assert_eq!(word.infix(1, 3).to_string(), "bcd");
+    /// use automata::word::{LinearWord, FiniteWord};
+    /// let word = "abcde".to_string();
+    /// assert_eq!(word.infix(1, 3).as_string(), "bcd");
     /// ```
     fn infix(&self, offset: usize, length: usize) -> Infix<'_, S, Self>
     where
@@ -54,7 +54,7 @@ pub trait LinearWord<S>: Hash + Eq {
         Infix::new(self, offset, length)
     }
 
-    /// Constructs a [`Prefix`] object, which is a finite prefix of `self` that has the given `length`.
+    /// Constructs an [`Infix`] object, which is a finite prefix of `self` that has the given `length`.
     fn prefix(&self, length: usize) -> Infix<'_, S, Self>
     where
         Self: Sized,

--- a/automata/src/word/mod.rs
+++ b/automata/src/word/mod.rs
@@ -24,8 +24,11 @@ use tracing::subscriber::SetGlobalDefaultError;
 
 use self::subword::Infix;
 
+/// A linear word is a word that can be indexed by a `usize`. This is the case for both finite and
+/// infinite words.
 #[autoimpl(for<T: trait + ?Sized> &T, &mut T)]
 pub trait LinearWord<S>: Hash + Eq {
+    /// Returns the symbol at the given `position` in `self`, if it exists.
     fn nth(&self, position: usize) -> Option<S>;
 
     /// Returns the first symbol of `self`, if it exists.
@@ -36,6 +39,14 @@ pub trait LinearWord<S>: Hash + Eq {
         self.nth(0)
     }
 
+    /// Builds an infix of `self` by starting at the given `offset` and taking the given `length`.
+    ///
+    /// # Example
+    /// ```
+    /// use automata::word::LinearWord;
+    /// let word = "abcde";
+    /// assert_eq!(word.infix(1, 3).to_string(), "bcd");
+    /// ```
     fn infix(&self, offset: usize, length: usize) -> Infix<'_, S, Self>
     where
         Self: Sized,
@@ -69,6 +80,11 @@ pub trait LinearWord<S>: Hash + Eq {
     }
 }
 
+/// A type of iterator for infixes of [`LinearWord`]s. It is actually consumed by iteration.
+///
+/// Stores a reference to the iterated word as well as a start and end position. When `next` is called,
+/// we check if the start position is strictly smaller than the end position, and if so, we return the symbol at
+/// the start position and increment it. Otherwise, we return `None`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ConsumingInfixIterator<'a, S: Symbol, W: LinearWord<S>> {
     word: &'a W,
@@ -97,6 +113,7 @@ impl<'a, S: Symbol, W: LinearWord<S>> Iterator for ConsumingInfixIterator<'a, S,
 }
 
 impl<'a, S: Symbol, W: LinearWord<S>> ConsumingInfixIterator<'a, S, W> {
+    /// Creates a new [`ConsumingInfixIterator`] object from a reference to a word and a start and end position.
     pub fn new(word: &'a W, start: usize, end: usize) -> Self {
         Self {
             word,

--- a/automata/src/word/omega.rs
+++ b/automata/src/word/omega.rs
@@ -145,12 +145,17 @@ impl<S: Symbol> Periodic<S> {
     /// let word = Periodic::new("abcabcabc");
     /// assert_eq!(word.cycle_length(), 3);
     /// assert_eq!(word.loop_index(), 0);
-    /// assert_eq!(word, Periodic { representation: vec!['a', 'b', 'c'] });
+    /// assert_eq!(word.representation(), &['a', 'b', 'c']);
     /// ```
     pub fn new<W: FiniteWord<S>>(word: W) -> Self {
         let mut representation = word.to_vec();
         deduplicate_inplace(&mut representation);
         Self { representation }
+    }
+
+    /// Gives a reference to the underlying representation of the word.
+    pub fn representation(&self) -> &[S] {
+        &self.representation
     }
 }
 

--- a/check
+++ b/check
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+cargo fmt --check --all
+echo "cargo fmt --check --all passed"
+cargo clippy --workspace -- -D warnings
+echo "cargo clippy --all -- -D warnings passed"
+cargo doc --workspace --no-deps 
+cargo test --all
+echo "cargo test --all passed"

--- a/hoars/src/body.rs
+++ b/hoars/src/body.rs
@@ -5,7 +5,7 @@ use chumsky::prelude::*;
 
 use crate::{lexer::Token, value, AcceptanceSignature, AtomicProposition, Id, StateConjunction};
 
-/// Newtype wrapper around a [`LabelExpression`], implements [`Deref`].
+/// Newtype wrapper around a [`crate::LabelExpression`], implements [`Deref`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Label(pub Bdd);
 
@@ -34,7 +34,7 @@ struct ExplicitEdge(Label, StateConjunction, Option<AcceptanceSignature>);
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ImplicitEdge(StateConjunction, Option<AcceptanceSignature>);
 
-/// Represents an edge in a HOA automaton. It contains the [`LabelExpression`], the
+/// Represents an edge in a HOA automaton. It contains the [`crate::LabelExpression`], the
 /// [`StateConjunction`] and the [`AcceptanceSignature`] of the edge.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Edge(

--- a/hoars/src/lib.rs
+++ b/hoars/src/lib.rs
@@ -112,7 +112,7 @@ pub struct HoaAutomaton {
 pub type HoaAcceptance = (usize, AcceptanceCondition);
 
 /// Stores information on aliases, it holds a vector of pairs of alias
-/// names and label expression. This can be used to [unalias](HoaAutomaton::unalias) an automaton.
+/// names and label expression. This can be used to unalias an automaton.
 pub type Aliases = Vec<(AliasName, LabelExpression)>;
 
 impl HoaAutomaton {
@@ -157,8 +157,7 @@ impl HoaAutomaton {
     }
 
     /// Creates a new HOA automaton from the given version, header and
-    /// body. This function will also [unalias](HoaAutomaton::unalias) the
-    /// automaton.
+    /// body. This function will also unalias the automaton.
     pub fn from_parts(header: Header, body: Body) -> Self {
         let mut out = Self { header, body };
         out.body.sort_by(|x, y| x.0.cmp(&y.0));


### PR DESCRIPTION
The `automata` package now forbids missing documentation on any publicly available method via `#![deny(missing_docs)]`.

All public facing methods have now been given (at least a rudimentary) documentation. There are now also some examples, although the documentation is not through enough for a public release.

On top of that, the CI integration has been made a bit more strict and it now also verifies that intra-doc links are valid, as enforced by `#![deny(rustdoc::broken_intra_doc_links)]`.

We introduced a build script `check` in the root of the repository, which runs the commands executed by the CI on the local machine.