### PR TITLE
Introduce `Void` type to replace unit type `()` wherever possible

### DIFF
--- a/automata-learning/src/active/lstar.rs
+++ b/automata-learning/src/active/lstar.rs
@@ -486,7 +486,6 @@ mod tests {
         let mut lstar = super::LStar::for_moore(alphabet, oracle);
 
         let mm = lstar.infer();
-        println!("{:?}", mm);
 
         assert_eq!(mm.try_moore_map("abba").unwrap(), 1);
         assert_eq!(mm.try_moore_map("ab").unwrap(), 0);
@@ -501,18 +500,18 @@ mod tests {
         let q1 = dfa.add_state(false);
         let q2 = dfa.add_state(true);
         let q3 = dfa.add_state(false);
-        dfa.add_edge(q0, 'a', q1, ());
-        dfa.add_edge(q0, 'b', q3, ());
-        dfa.add_edge(q0, 'c', q0, ());
-        dfa.add_edge(q1, 'a', q0, ());
-        dfa.add_edge(q1, 'b', q2, ());
-        dfa.add_edge(q1, 'c', q0, ());
-        dfa.add_edge(q2, 'a', q2, ());
-        dfa.add_edge(q2, 'b', q2, ());
-        dfa.add_edge(q2, 'c', q0, ());
-        dfa.add_edge(q3, 'a', q3, ());
-        dfa.add_edge(q3, 'b', q3, ());
-        dfa.add_edge(q3, 'c', q0, ());
+        dfa.add_edge(q0, 'a', q1, Void);
+        dfa.add_edge(q0, 'b', q3, Void);
+        dfa.add_edge(q0, 'c', q0, Void);
+        dfa.add_edge(q1, 'a', q0, Void);
+        dfa.add_edge(q1, 'b', q2, Void);
+        dfa.add_edge(q1, 'c', q0, Void);
+        dfa.add_edge(q2, 'a', q2, Void);
+        dfa.add_edge(q2, 'b', q2, Void);
+        dfa.add_edge(q2, 'c', q0, Void);
+        dfa.add_edge(q3, 'a', q3, Void);
+        dfa.add_edge(q3, 'b', q3, Void);
+        dfa.add_edge(q3, 'c', q0, Void);
         dfa
     }
 

--- a/automata-learning/src/active/mealy.rs
+++ b/automata-learning/src/active/mealy.rs
@@ -32,6 +32,7 @@ impl<A: Alphabet, C: Color> LStarHypothesis for MooreMachine<A, C> {
         experiments: &super::Experiments<Self>,
         row: &[Self::Color],
     ) -> Self::EdgeColor {
+        Void
     }
 
     fn mandatory_experiments(
@@ -56,6 +57,7 @@ impl<C: Color> LStarHypothesis for MealyMachine<Simple, C> {
         experiments: &super::Experiments<Self>,
         row: &[Self::Color],
     ) -> Self::StateColor {
+        Void
     }
 
     fn give_transition_color(
@@ -113,5 +115,6 @@ impl LStarHypothesis for DFA {
         experiments: &super::Experiments<Self>,
         row: &[Self::Color],
     ) -> Self::EdgeColor {
+        Void
     }
 }

--- a/automata-learning/src/active/oracle.rs
+++ b/automata-learning/src/active/oracle.rs
@@ -197,14 +197,16 @@ impl<D: DFALike<Alphabet = Simple>> LStarOracle<MooreMachine<Simple, bool>> for 
 }
 
 /// An oracle based on a [`MealyMachine`].
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MealyOracle<D: MealyLike + Deterministic> {
     automaton: IntoMealyMachine<D>,
     default: Option<D::EdgeColor>,
 }
 
-impl<D: MealyLike + Deterministic<Alphabet = Simple>>
-    LStarOracle<MealyMachine<Simple, D::EdgeColor>> for MealyOracle<D>
+impl<D> LStarOracle<MealyMachine<Simple, D::EdgeColor>> for MealyOracle<D>
+where
+    D: Congruence<Alphabet = Simple>,
+    EdgeColor<D>: Color,
 {
     type Length = FiniteLength;
 
@@ -253,7 +255,11 @@ impl<D: MealyLike + Deterministic<Alphabet = Simple>>
     }
 }
 
-impl<D: MealyLike + Deterministic> MealyOracle<D> {
+impl<D> MealyOracle<D>
+where
+    D: Congruence,
+    EdgeColor<D>: Color,
+{
     /// Creates a new [`MealyOracle`] based on an instance of [`MealyLike`].
     pub fn new(automaton: D, default: Option<D::EdgeColor>) -> Self {
         Self {
@@ -269,12 +275,14 @@ impl<D: MealyLike + Deterministic> MealyOracle<D> {
 
 /// An oracle based on a [`MooreMachine`].
 #[derive(Debug, Clone)]
-pub struct MooreOracle<D: MooreLike> {
+pub struct MooreOracle<D> {
     automaton: D,
 }
 
 impl<D: MooreLike<Alphabet = Simple>> LStarOracle<MooreMachine<Simple, D::StateColor>>
     for MooreOracle<D>
+where
+    StateColor<D>: Color,
 {
     type Length = FiniteLength;
 
@@ -296,7 +304,11 @@ impl<D: MooreLike<Alphabet = Simple>> LStarOracle<MooreMachine<Simple, D::StateC
     }
 }
 
-impl<D: MooreLike> MooreOracle<D> {
+impl<D> MooreOracle<D>
+where
+    D: Congruence,
+    EdgeColor<D>: Color,
+{
     /// Creates a new [`MooreOracle`] based on an instance of [`MooreLike`].
     pub fn new(automaton: D) -> Self {
         Self { automaton }

--- a/automata-learning/src/passive/mod.rs
+++ b/automata-learning/src/passive/mod.rs
@@ -97,14 +97,14 @@ pub fn infer_precise_dpa<A: Alphabet>(
 }
 
 /// Similar to [`dba_rpni`], but produces a DPA instead.
-pub fn dpa_rpni(sample: &OmegaSample<Simple, bool>) -> DPA<Simple, (), MealyMachine> {
+pub fn dpa_rpni(sample: &OmegaSample<Simple, bool>) -> DPA<Simple, Void, MealyMachine> {
     let precise = infer_precise_dpa(sample);
     let pta = sample.prefix_tree().erase_state_colors();
 
     let prod = pta
         .ts_product(precise)
         .map_edge_colors(|(_, c)| c)
-        .map_state_colors(|(_, _)| ());
+        .erase_state_colors();
     let completed = prod.trim_collect();
 
     //now we use the completed thing to learn a MealyMachine from which we can then build the DPA

--- a/automata-learning/src/passive/precise.rs
+++ b/automata-learning/src/passive/precise.rs
@@ -7,9 +7,9 @@ use automata::{
     ts::{
         dot::{DotStateAttribute, DotTransitionAttribute},
         reachable::ReachableStateIndices,
-        Deterministic, Dottable, IndexType, Sproutable,
+        Deterministic, Dottable, EdgeColor, ExpressionOf, IndexType, Sproutable, StateColor,
     },
-    Alphabet, Map, Pointed, RightCongruence, Show, TransitionSystem,
+    Alphabet, Map, Pointed, RightCongruence, Show, TransitionSystem, Void,
 };
 use itertools::Itertools;
 use tracing::{info, trace};
@@ -279,7 +279,7 @@ pub struct PreciseDPAStatesIter<'a, A: Alphabet, const N: usize = 8> {
 impl<A: Alphabet, const N: usize> TransitionSystem for PreciseDPA<A, N> {
     type StateIndex = PState<N>;
 
-    type StateColor = ();
+    type StateColor = Void;
 
     type EdgeColor = usize;
 
@@ -303,7 +303,7 @@ impl<A: Alphabet, const N: usize> TransitionSystem for PreciseDPA<A, N> {
     }
 
     fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        Some(())
+        Some(Void)
     }
 
     fn edges_from<Idx: automata::prelude::Indexes<Self>>(
@@ -443,7 +443,7 @@ fn padding_universal_dfa<A: Alphabet>(alphabet: &A) -> DFA<A> {
     let e = dfa.initial();
     dfa.set_initial_color(true);
     for sym in alphabet.universe() {
-        dfa.add_edge(e, A::expression(sym), e, ());
+        dfa.add_edge(e, A::expression(sym), e, Void);
     }
     dfa
 }
@@ -493,7 +493,10 @@ impl<A: Alphabet, const N: usize> Dottable for PreciseDPA<A, N> {
     fn dot_state_attributes(
         &self,
         idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = automata::ts::dot::DotStateAttribute> {
+    ) -> impl IntoIterator<Item = automata::ts::dot::DotStateAttribute>
+    where
+        (String, StateColor<Self>): Show,
+    {
         [
             DotStateAttribute::Shape("box".to_string()),
             DotStateAttribute::Label(idx.to_string()),
@@ -503,7 +506,10 @@ impl<A: Alphabet, const N: usize> Dottable for PreciseDPA<A, N> {
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = automata::ts::dot::DotTransitionAttribute> {
+    ) -> impl IntoIterator<Item = automata::ts::dot::DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         [DotTransitionAttribute::Label(format!(
             "{}|{}",
             t.expression().show(),
@@ -524,62 +530,62 @@ mod tests {
 
         let cong = NTS::builder()
             .with_transitions([
-                (0, 'a', (), 1),
-                (0, 'b', (), 0),
-                (0, 'c', (), 0),
-                (1, 'a', (), 0),
-                (1, 'b', (), 1),
-                (1, 'c', (), 1),
+                (0, 'a', Void, 1),
+                (0, 'b', Void, 0),
+                (0, 'c', Void, 0),
+                (1, 'a', Void, 0),
+                (1, 'b', Void, 1),
+                (1, 'c', Void, 1),
             ])
             .default_color(())
             .into_right_congruence_bare(0);
 
         let de0 = NTS::builder()
             .with_transitions([
-                (0, 'a', (), 0),
-                (0, 'b', (), 1),
-                (0, 'c', (), 0),
-                (1, 'a', (), 1),
-                (1, 'b', (), 1),
-                (1, 'c', (), 1),
+                (0, 'a', Void, 0),
+                (0, 'b', Void, 1),
+                (0, 'c', Void, 0),
+                (1, 'a', Void, 1),
+                (1, 'b', Void, 1),
+                (1, 'c', Void, 1),
             ])
             .with_colors([false, true])
             .into_dfa(0);
         let da0 = NTS::builder()
             .with_transitions([
-                (0, 'a', (), 0),
-                (0, 'b', (), 0),
-                (0, 'c', (), 1),
-                (1, 'a', (), 1),
-                (1, 'b', (), 1),
-                (1, 'c', (), 1),
+                (0, 'a', Void, 0),
+                (0, 'b', Void, 0),
+                (0, 'c', Void, 1),
+                (1, 'a', Void, 1),
+                (1, 'b', Void, 1),
+                (1, 'c', Void, 1),
             ])
             .with_colors([false, true])
             .into_dfa(0);
 
         let de1 = NTS::builder()
             .with_transitions([
-                (0, 'a', (), 0),
-                (0, 'b', (), 2),
-                (0, 'c', (), 1),
-                (1, 'a', (), 0),
-                (1, 'b', (), 2),
-                (1, 'c', (), 2),
-                (2, 'a', (), 2),
-                (2, 'b', (), 2),
-                (2, 'c', (), 2),
+                (0, 'a', Void, 0),
+                (0, 'b', Void, 2),
+                (0, 'c', Void, 1),
+                (1, 'a', Void, 0),
+                (1, 'b', Void, 2),
+                (1, 'c', Void, 2),
+                (2, 'a', Void, 2),
+                (2, 'b', Void, 2),
+                (2, 'c', Void, 2),
             ])
             .with_colors([false, false, true])
             .into_dfa(0);
 
         let full = NTS::builder()
             .with_transitions([
-                (0, 'a', (), 1),
-                (0, 'b', (), 1),
-                (0, 'c', (), 1),
-                (1, 'a', (), 1),
-                (1, 'b', (), 1),
-                (1, 'c', (), 1),
+                (0, 'a', Void, 1),
+                (0, 'b', Void, 1),
+                (0, 'c', Void, 1),
+                (1, 'a', Void, 1),
+                (1, 'b', Void, 1),
+                (1, 'c', Void, 1),
             ])
             .with_colors([false, true])
             .into_dfa(0);

--- a/automata-learning/src/passive/sample/characterize.rs
+++ b/automata-learning/src/passive/sample/characterize.rs
@@ -356,7 +356,11 @@ where
     cong
 }
 
-pub fn characterize_moore<M: MooreLike>(dfa: M) -> DFASample<M> {
+pub fn characterize_moore<M>(dfa: M) -> DFASample<M>
+where
+    M: Congruence,
+    StateColor<M>: Color,
+{
     todo!()
 }
 
@@ -367,7 +371,11 @@ pub fn actively_exchanged_words_dfa<D: DFALike>(dfa: D) -> DFASample<D> {
 type MealySample<D> =
     Sample<<D as TransitionSystem>::Alphabet, Vec<SymbolOf<D>>, <D as TransitionSystem>::EdgeColor>;
 
-pub fn actively_exchanged_words_mealy<D: MealyLike + Deterministic>(mm: D) -> MealySample<D> {
+pub fn actively_exchanged_words_mealy<D>(mm: D) -> MealySample<D>
+where
+    D: Congruence,
+    EdgeColor<D>: Color,
+{
     let alphabet = mm.alphabet().clone();
     let oracle = MealyOracle::new(mm, None);
     // let mut lstar = LStar::logged(oracle, alphabet);

--- a/automata-learning/src/passive/sprout.rs
+++ b/automata-learning/src/passive/sprout.rs
@@ -299,7 +299,7 @@ where
     C: ConsistencyCheck<A>,
 {
     let mut cong = RightCongruence::new(conflicts.alphabet().clone());
-    let initial = cong.add_state((vec![], ()));
+    let initial = cong.add_state((vec![], Void));
     let threshold = conflicts.threshold();
 
     // We maintain a set of missing transitions and go through them in order of creation for the states and in order
@@ -325,7 +325,7 @@ where
             if !allow_transitions_into_epsilon && target == initial {
                 continue;
             }
-            let old_edge = cong.add_edge(source, A::expression(sym), target, ());
+            let old_edge = cong.add_edge(source, A::expression(sym), target, Void);
 
             if conflicts.consistent(&cong)
                 && additional_constraints.iter().all(|c| c.consistent(&cong))
@@ -375,7 +375,7 @@ where
         if new_state > threshold {
             panic!("TOO MANY STATES")
         }
-        cong.add_edge(source, A::expression(sym), new_state, ());
+        cong.add_edge(source, A::expression(sym), new_state, Void);
         queue.extend(std::iter::repeat(new_state).zip(conflicts.alphabet().universe()))
     }
 

--- a/automata-learning/src/prefixtree.rs
+++ b/automata-learning/src/prefixtree.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use automata::{
     ts::Sproutable, word::OmegaWord, Alphabet, HasLength, InfiniteLength, Map, Pointed,
-    RightCongruence, Set,
+    RightCongruence, Set, Void,
 };
 use itertools::Itertools;
 use tracing::trace;
@@ -27,18 +27,18 @@ pub fn prefix_tree<A: Alphabet, W: Into<Reduced<A::Symbol>>, I: IntoIterator<Ite
             access.push(*symbol);
             trace!("adding state {:?}", access);
             let next = tree.add_state(access.clone());
-            tree.add_edge(current, A::expression(*symbol), next, ());
+            tree.add_edge(current, A::expression(*symbol), next, Void);
             current = next;
         }
         tree.add_edge(
             current,
             A::expression(loop_segment[loop_segment.len() - 1]),
             state,
-            (),
+            Void,
         );
     }
     let mut tree = RightCongruence::new(alphabet.clone());
-    let root = tree.add_state((vec![], ()));
+    let root = tree.add_state((vec![], Void));
 
     let mut queue = VecDeque::from_iter([(root, vec![], words.to_vec())]);
 
@@ -69,7 +69,7 @@ pub fn prefix_tree<A: Alphabet, W: Into<Reduced<A::Symbol>>, I: IntoIterator<Ite
                         .collect_vec();
                     trace!("Adding state {:?}", new_access);
                     let successor = tree.add_state(new_access.clone());
-                    tree.add_edge(state, A::expression(sym), successor, ());
+                    tree.add_edge(state, A::expression(sym), successor, Void);
                     queue.push_back((successor, new_access, new_words.into_iter().collect()));
                 }
             }
@@ -86,7 +86,7 @@ mod tests {
         ts::{Deterministic, Dottable, Sproutable},
         upw,
         word::Periodic,
-        TransitionSystem,
+        TransitionSystem, Void,
     };
 
     use super::prefix_tree;
@@ -98,7 +98,7 @@ mod tests {
         let pta = prefix_tree(alphabet, words);
         let completed = pta
             .erase_state_colors()
-            .collect_complete_with_initial((), ());
+            .collect_complete_with_initial(Void, Void);
         let lead_to_sink = ["ba", "bbbbbbbbba", "ababababbbabaababa", "aaaaaaaaaaaaab"];
         for w in &lead_to_sink {
             for v in &lead_to_sink {

--- a/automata-learning/src/priority_mapping.rs
+++ b/automata-learning/src/priority_mapping.rs
@@ -91,7 +91,7 @@ impl Annotation {
 /// This a simple newtype wrapper around a congruence, which has no edge colors and uses
 /// [`Annotation`]s as state colors.
 #[derive(Clone)]
-pub struct AnnotatedCongruence<A: Alphabet = Simple>(RightCongruence<A, Annotation, ()>);
+pub struct AnnotatedCongruence<A: Alphabet = Simple>(RightCongruence<A, Annotation, Void>);
 
 #[autoimpl(for<T: trait + ?Sized> &T)]
 pub trait ClassifiesIdempotents<A: Alphabet> {
@@ -167,8 +167,8 @@ impl<A: Alphabet> AnnotatedCongruence<A> {
     /// of the congruence to construct an annotated congruence.
     pub fn build<Q, C, F>(rc: &RightCongruence<A, Q, C>, f: F) -> Self
     where
-        Q: Color,
-        C: Color,
+        Q: Clone,
+        C: Clone,
         F: ClassifiesIdempotents<A>,
     {
         Self(

--- a/automata/src/acceptance.rs
+++ b/automata/src/acceptance.rs
@@ -116,7 +116,7 @@ where
     }
 }
 
-pub type DFA<A, Idx = usize, Q = bool, E = ()> =
+pub type DFA<A, Idx = usize, Q = bool, E = Void> =
     Automaton<IndexTS<A, Idx, Q, E>, ReachabilityCondition>;
 
 impl<Ts> Acceptor<Ts::Alphabet, InfiniteLength> for Automaton<Ts, BuchiCondition>
@@ -136,7 +136,7 @@ where
     }
 }
 
-pub type DBA<A, Idx = usize, Q = (), E = bool> = Automaton<IndexTS<A, Idx, Q, E>, BuchiCondition>;
+pub type DBA<A, Idx = usize, Q = Void, E = bool> = Automaton<IndexTS<A, Idx, Q, E>, BuchiCondition>;
 
 impl<Ts> Acceptor<Ts::Alphabet, InfiniteLength> for Automaton<Ts, ParityCondition>
 where
@@ -159,4 +159,4 @@ where
     }
 }
 
-pub type DPA<A, Idx = usize, Q = (), E = u8> = Automaton<IndexTS<A, Idx, Q, E>, ParityCondition>;
+pub type DPA<A, Idx = usize, Q = Void, E = u8> = Automaton<IndexTS<A, Idx, Q, E>, ParityCondition>;

--- a/automata/src/algorithms/partition_refinement.rs
+++ b/automata/src/algorithms/partition_refinement.rs
@@ -25,7 +25,11 @@ use crate::{
 /// partition is a [`Partition`] of the state indices, where any states in the same class of the
 /// returned partition are pairwise bisimilar. This means for any *non-empty* input, they produce
 /// the same sequence of outputs.
-pub fn mealy_greatest_bisimulation<M: MealyLike>(mm: M) -> Partition<M::StateIndex> {
+pub fn mealy_greatest_bisimulation<D>(mm: D) -> Partition<D::StateIndex>
+where
+    D: Deterministic,
+    EdgeColor<D>: Color,
+{
     let start = Instant::now();
     let mut queue: Vec<BTreeSet<_>> = vec![mm.state_indices().collect()];
 
@@ -82,7 +86,11 @@ pub fn mealy_greatest_bisimulation<M: MealyLike>(mm: M) -> Partition<M::StateInd
 /// Partition refinement algorithm for deterministic finite automata that have outputs on the edges.
 /// Runs in O(n log n) time, where n is the number of states of the automaton and returns the unique
 /// minimal automaton that is bisimilar to the input.
-pub fn mealy_partition_refinement<M: MealyLike>(mm: M) -> AsMealyMachine<M> {
+pub fn mealy_partition_refinement<D>(mm: D) -> AsMealyMachine<D>
+where
+    D: Congruence,
+    EdgeColor<D>: Color,
+{
     let partition = mealy_greatest_bisimulation(&mm);
     trace!(
         "Building quotient with partition {{{}}}",
@@ -115,7 +123,11 @@ pub fn mealy_partition_refinement<M: MealyLike>(mm: M) -> AsMealyMachine<M> {
 /// Two states of a mealy machine are considered to be bisimilar if and only if they have the same
 /// output on all words. This gives a [`Partition`] of the state indices, where any states in the
 /// same class of the returned partition are pairwise bisimilar.
-pub fn moore_greatest_bisimulation<M: MooreLike>(mm: M) -> Partition<M::StateIndex> {
+pub fn moore_greatest_bisimulation<D>(mm: D) -> Partition<D::StateIndex>
+where
+    D: Deterministic,
+    StateColor<D>: Color,
+{
     let start = Instant::now();
 
     let mut presplit: Map<_, _> = Map::default();
@@ -174,7 +186,11 @@ pub fn moore_greatest_bisimulation<M: MooreLike>(mm: M) -> Partition<M::StateInd
 /// minimal automaton that is bisimilar to the input. This method computes the maximal bisimulation
 /// by using [`moore_greatest_bisimulation`] and then uses the partition to compute the quotient
 /// automaton.
-pub fn moore_partition_refinement<D: MooreLike>(mm: D) -> AsMooreMachine<D> {
+pub fn moore_partition_refinement<D>(mm: D) -> AsMooreMachine<D>
+where
+    D: Congruence,
+    StateColor<D>: Color,
+{
     let partition = moore_greatest_bisimulation(&mm);
     trace!(
         "Building quotient with partition {{{}}}",

--- a/automata/src/automaton/acceptor.rs
+++ b/automata/src/automaton/acceptor.rs
@@ -1,10 +1,13 @@
 use crate::{
     prelude::Symbol,
-    ts::SymbolOf,
+    ts::{EdgeColor, StateColor, SymbolOf},
     word::{FiniteWord, OmegaWord},
+    Color,
 };
 
-use super::{DFALike, IntoDFA, IntoMealyMachine, IntoMooreMachine, MealyLike, MooreLike};
+use super::{
+    Congruence, DFALike, IntoDFA, IntoMealyMachine, IntoMooreMachine, MealyLike, MooreLike,
+};
 
 /// Implementors of this trait transform finite inputs into some other type. For example,
 /// a DFA maps each finite word over its input alphabet to a boolean value, indicating
@@ -22,13 +25,20 @@ pub trait FiniteWordTransformer<S, C> {
     fn transform_finite<W: FiniteWord<S>>(&self, word: W) -> C;
 }
 
-impl<D: MooreLike> FiniteWordTransformer<SymbolOf<D>, D::StateColor> for IntoMooreMachine<D> {
+impl<D: MooreLike> FiniteWordTransformer<SymbolOf<D>, D::StateColor> for IntoMooreMachine<D>
+where
+    StateColor<D>: Color,
+{
     fn transform_finite<W: FiniteWord<SymbolOf<D>>>(&self, word: W) -> D::StateColor {
         self.try_moore_map(word).expect("Transformer must be total")
     }
 }
 
-impl<D: MealyLike> FiniteWordTransformer<SymbolOf<D>, D::EdgeColor> for IntoMealyMachine<D> {
+impl<D> FiniteWordTransformer<SymbolOf<D>, D::EdgeColor> for IntoMealyMachine<D>
+where
+    D: Congruence,
+    EdgeColor<D>: Color,
+{
     fn transform_finite<W: FiniteWord<SymbolOf<D>>>(&self, word: W) -> D::EdgeColor {
         self.try_mealy_map(word).expect("Transformer must be total")
     }

--- a/automata/src/automaton/dba.rs
+++ b/automata/src/automaton/dba.rs
@@ -4,6 +4,14 @@ use super::acceptor::OmegaWordAcceptor;
 
 impl_mealy_automaton!(DBA, bool);
 
+impl<D: DBALike> OmegaWordAcceptor<SymbolOf<D>> for IntoDBA<D> {
+    fn accepts_omega<W: OmegaWord<SymbolOf<Self>>>(&self, word: W) -> bool {
+        self.recurrent_edge_colors(word)
+            .map(|mut colors| colors.any(|b| b))
+            .unwrap_or(false)
+    }
+}
+
 /// Similar to [`DFALike`], this trait is supposed to be (automatically) implemented by everything that can be viewed
 /// as a [`crate::DBA`].
 pub trait DBALike: Deterministic<EdgeColor = bool> + Pointed {
@@ -56,11 +64,3 @@ pub trait DBALike: Deterministic<EdgeColor = bool> + Pointed {
 }
 
 impl<Ts> DBALike for Ts where Ts: Deterministic<EdgeColor = bool> + Pointed {}
-
-impl<A: Alphabet> OmegaWordAcceptor<A::Symbol> for DBA<A> {
-    fn accepts_omega<W: OmegaWord<A::Symbol>>(&self, word: W) -> bool {
-        self.recurrent_edge_colors(word)
-            .map(|mut set| set.any(|x| x))
-            .unwrap_or(false)
-    }
-}

--- a/automata/src/automaton/mealy.rs
+++ b/automata/src/automaton/mealy.rs
@@ -218,15 +218,17 @@ where
 
 impl<Ts: Deterministic> std::fmt::Debug for MealyMachine<Ts::Alphabet, Ts::EdgeColor, Ts>
 where
-    EdgeColor<Ts>: Show,
-    StateColor<Ts>: Show,
+    EdgeColor<Ts>: Debug,
+    StateColor<Ts>: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
-            self.ts
-                .build_transition_table(|q, c| format!("({}|{})", q.show(), c.show()))
+            self.ts.build_transition_table(
+                |q, c| format!("({:?}|{:?})", q, c),
+                |edge| format!("{:?}->{}", edge.color(), edge.target())
+            )
         )
     }
 }

--- a/automata/src/automaton/mod.rs
+++ b/automata/src/automaton/mod.rs
@@ -58,7 +58,7 @@ pub use with_initial::Initialized;
 
 /// Type alias for the unit type. Purpose is mainly to be used in Macros, as `()` is more difficult to
 /// handle than a simple alphabetic identifier.
-pub type NoColor = ();
+pub type NoColor = Void;
 
 #[allow(missing_docs)]
 macro_rules! impl_automaton_type {

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -34,21 +34,15 @@ impl<Ts: TransitionSystem> Pointed for Initialized<Ts> {
 impl<Ts> std::fmt::Debug for Initialized<Ts>
 where
     Ts: Deterministic + Debug,
-    Ts::StateColor: Show,
-    Ts::EdgeColor: Show,
+    Ts::StateColor: Debug,
+    Ts::EdgeColor: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "Initial state {} with table\n{}",
+            "Initialized to state {} with table\n{:?}",
             self.initial(),
-            self.build_transition_table(|index, color| {
-                if index == self.initial() {
-                    format!("{} : {}", index.to_string().bold(), color.show())
-                } else {
-                    format!("{} : {}", index, color.show())
-                }
-            })
+            self.ts()
         )
     }
 }

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -62,8 +62,8 @@ impl<Ts: TransitionSystem> From<(Ts, Ts::StateIndex)> for Initialized<Ts> {
 impl<A, C, Q> Initialized<DTS<A, Q, C>>
 where
     A: Alphabet,
-    C: Color,
-    Q: Color,
+    C: Clone,
+    Q: Clone,
 {
     /// Takes an alphabet and a color and constructs an [`Initialized`] instance with the given alphabet, no
     /// transitions and a single initial state with the given color.

--- a/automata/src/congruence/class.rs
+++ b/automata/src/congruence/class.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 
-use crate::prelude::*;
+use crate::{prelude::*, Void};
 
 /// Represents a congruence class, which is in essence simply a non-empty sequence of symbols
 /// for the underlying alphabet.
@@ -22,7 +22,7 @@ impl<S: Show> Show for Class<S> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Indexes<RightCongruence<A, Q, C>> for Class<A::Symbol> {
+impl<A: Alphabet, Q: Clone, C: Clone> Indexes<RightCongruence<A, Q, C>> for Class<A::Symbol> {
     #[inline(always)]
     fn to_index(
         &self,
@@ -31,7 +31,7 @@ impl<A: Alphabet, Q: Color, C: Color> Indexes<RightCongruence<A, Q, C>> for Clas
         ts.class_to_index(self).or(ts.reached_state_index(self))
     }
 }
-impl<'a, A: Alphabet, Q: Color, C: Color> Indexes<RightCongruence<A, Q, C>>
+impl<'a, A: Alphabet, Q: Clone, C: Clone> Indexes<RightCongruence<A, Q, C>>
     for &'a Class<A::Symbol>
 {
     #[inline(always)]
@@ -177,7 +177,7 @@ pub struct ColoredClass<S: Symbol, Q = ()> {
     pub(crate) color: Q,
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Indexes<RightCongruence<A, Q, C>>
+impl<A: Alphabet, Q: Clone, C: Clone> Indexes<RightCongruence<A, Q, C>>
     for ColoredClass<A::Symbol, Q>
 {
     #[inline(always)]
@@ -188,7 +188,7 @@ impl<A: Alphabet, Q: Color, C: Color> Indexes<RightCongruence<A, Q, C>>
         self.class.to_index(ts)
     }
 }
-impl<'a, A: Alphabet, Q: Color, C: Color> Indexes<RightCongruence<A, Q, C>>
+impl<'a, A: Alphabet, Q: Clone, C: Clone> Indexes<RightCongruence<A, Q, C>>
     for &'a ColoredClass<A::Symbol, Q>
 {
     #[inline(always)]
@@ -206,16 +206,16 @@ impl<S: Symbol, Q: std::fmt::Debug> std::fmt::Display for ColoredClass<S, Q> {
     }
 }
 
-impl<S: Symbol, J: Into<Class<S>>> From<J> for ColoredClass<S, ()> {
+impl<S: Symbol, J: Into<Class<S>>> From<J> for ColoredClass<S, Void> {
     fn from(value: J) -> Self {
         Self {
             class: value.into(),
-            color: (),
+            color: Void,
         }
     }
 }
 
-impl<S: Symbol, W: FiniteWord<S>, Q: Color> From<(W, Q)> for ColoredClass<S, Q> {
+impl<S: Symbol, W: FiniteWord<S>, Q: Clone> From<(W, Q)> for ColoredClass<S, Q> {
     fn from(value: (W, Q)) -> Self {
         Self {
             class: value.0.to_vec().into(),
@@ -224,7 +224,7 @@ impl<S: Symbol, W: FiniteWord<S>, Q: Color> From<(W, Q)> for ColoredClass<S, Q> 
     }
 }
 
-impl<S: Symbol, Q: Color> ColoredClass<S, Q> {
+impl<S: Symbol, Q: Clone> ColoredClass<S, Q> {
     /// Creates a new colored class from the given class and color.
     pub fn new<X: Into<Class<S>>>(class: X, color: Q) -> Self {
         Self {
@@ -247,7 +247,7 @@ impl<S: Symbol, Q: Color> ColoredClass<S, Q> {
     }
 
     /// Consumes `self` and returns a [`ColoredClass`] with the same class but the given `color`.
-    pub fn recolor<D: Color>(self, color: D) -> ColoredClass<S, D> {
+    pub fn recolor<D: Clone>(self, color: D) -> ColoredClass<S, D> {
         ColoredClass {
             class: self.class,
             color,

--- a/automata/src/congruence/class.rs
+++ b/automata/src/congruence/class.rs
@@ -172,7 +172,7 @@ impl<S: Ord> PartialOrd for Class<S> {
 
 /// A colored class is a [`Class`] which additionally has an associated color.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct ColoredClass<S: Symbol, Q = ()> {
+pub struct ColoredClass<S: Symbol, Q = Void> {
     pub(crate) class: Class<S>,
     pub(crate) color: Q,
 }

--- a/automata/src/congruence/forc.rs
+++ b/automata/src/congruence/forc.rs
@@ -2,17 +2,19 @@ use std::fmt::Debug;
 
 use owo_colors::OwoColorize;
 
-use crate::{ts::transition_system::Indexes, Alphabet, Class, Color, Map, RightCongruence, Show};
+use crate::{
+    ts::transition_system::Indexes, Alphabet, Class, Color, Map, RightCongruence, Show, Void,
+};
 
 /// A family of right congruences (FORC) consists of a *leading* right congruence and for each
 /// class of this congruence a *progress* right congruence.
 #[derive(Clone, PartialEq, Eq)]
-pub struct FORC<A: Alphabet, Q: Color = (), C: Color = ()> {
+pub struct FORC<A: Alphabet, Q = Void, C = Void> {
     pub(crate) leading: RightCongruence<A>,
     pub(crate) progress: Map<usize, RightCongruence<A, Q, C>>,
 }
 
-impl<A: Alphabet, Q: Color, C: Color> FORC<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> FORC<A, Q, C> {
     /// Creates a new FORC with the given leading congruence and progress congruences.
     pub fn new(
         leading: RightCongruence<A>,
@@ -63,19 +65,19 @@ impl<A: Alphabet, Q: Color, C: Color> FORC<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color + Show, C: Color + Show> std::fmt::Debug for FORC<A, Q, C> {
+impl<A: Alphabet, Q: Clone + Show, C: Clone + Show> std::fmt::Debug for FORC<A, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}\n{:?}", "LEADING".bold(), self.leading())?;
-        for (c, rc) in self.prc_iter() {
-            let class_name = self.leading.class_name(*c).unwrap();
-            write!(
-                f,
-                "{} \"{}\"\n{:?}",
-                "PRC FOR CLASS ".bold(),
-                &class_name,
-                rc
-            )?;
-        }
-        Ok(())
+        // write!(f, "{}\n{:?}", "LEADING".bold(), self.leading())?;
+        // for (c, rc) in self.prc_iter() {
+        //     let class_name = self.leading.class_name(*c).unwrap();
+        //     write!(
+        //         f,
+        //         "{} \"{}\"\n{:?}",
+        //         "PRC FOR CLASS ".bold(),
+        //         &class_name,
+        //         rc
+        //     )?;
+        // }
+        todo!()
     }
 }

--- a/automata/src/congruence/forc.rs
+++ b/automata/src/congruence/forc.rs
@@ -65,7 +65,7 @@ impl<A: Alphabet, Q: Clone, C: Clone> FORC<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Clone + Show, C: Clone + Show> std::fmt::Debug for FORC<A, Q, C> {
+impl<A: Alphabet, Q: Clone + Debug, C: Clone + Debug> std::fmt::Debug for FORC<A, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // write!(f, "{}\n{:?}", "LEADING".bold(), self.leading())?;
         // for (c, rc) in self.prc_iter() {

--- a/automata/src/congruence/mod.rs
+++ b/automata/src/congruence/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     prelude::DFALike,
     ts::{transition_system::Indexes, Deterministic, Sproutable, DTS},
     word::FiniteWord,
-    Alphabet, Color, FiniteLength, HasLength, Map, Pointed, Show, TransitionSystem, DFA,
+    Alphabet, Color, FiniteLength, HasLength, Map, Pointed, Show, TransitionSystem, Void, DFA,
 };
 
 mod class;
@@ -25,7 +25,7 @@ mod cayley;
 /// represent these as a transition system, where the states are the equivalence classes and the colors
 /// on edges are `()`.
 #[derive(Clone, Eq, PartialEq)]
-pub struct RightCongruence<A: Alphabet = Simple, Q = (), C: Color = ()> {
+pub struct RightCongruence<A: Alphabet = Simple, Q = Void, C = Void> {
     ts: DTS<A, ColoredClass<A::Symbol, Q>, C>,
 }
 
@@ -44,7 +44,22 @@ impl<S: Symbol + Show, Q: Show> Show for ColoredClass<S, Q> {
     }
 }
 
-impl<A: Alphabet, Q: Color + Show, C: Color + Show> Debug for RightCongruence<A, Q, C> {
+impl<S: Symbol + Show> Show for ColoredClass<S, Void> {
+    fn show(&self) -> String {
+        self.class.show()
+    }
+
+    fn show_collection<'a, I>(iter: I) -> String
+    where
+        Self: 'a,
+        I: IntoIterator<Item = &'a Self>,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        todo!()
+    }
+}
+
+impl<A: Alphabet, Q: Clone + Show, C: Clone + Show> Debug for RightCongruence<A, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -55,7 +70,7 @@ impl<A: Alphabet, Q: Color + Show, C: Color + Show> Debug for RightCongruence<A,
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> RightCongruence<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> RightCongruence<A, Q, C> {
     /// Assumes that `self` is det. and complete.
     pub fn congruent<W, V>(&self, word: W, other: V) -> bool
     where
@@ -152,14 +167,14 @@ impl<A: Alphabet, Q: Color, C: Color> RightCongruence<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Pointed for RightCongruence<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> Pointed for RightCongruence<A, Q, C> {
     fn initial(&self) -> Self::StateIndex {
         assert!(!self.is_empty());
         0
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Sproutable for RightCongruence<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for RightCongruence<A, Q, C> {
     fn add_state<X: Into<crate::ts::StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {
         self.ts.add_state(color.into())
     }
@@ -209,7 +224,7 @@ impl<A: Alphabet, Q: Color, C: Color> Sproutable for RightCongruence<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color + Default, C: Color> RightCongruence<A, Q, C> {
+impl<A: Alphabet, Q: Clone + Default, C: Clone> RightCongruence<A, Q, C> {
     /// Creates a new [`RightCongruence`] for the given alphabet.
     pub fn new(alphabet: A) -> Self {
         Self::new_for_alphabet(alphabet)

--- a/automata/src/congruence/mod.rs
+++ b/automata/src/congruence/mod.rs
@@ -5,6 +5,7 @@ use itertools::{Itertools, MapInto};
 use crate::{
     alphabet::{Simple, Symbol},
     prelude::DFALike,
+    prelude::IsEdge,
     ts::{transition_system::Indexes, Deterministic, Sproutable, DTS},
     word::FiniteWord,
     Alphabet, Color, FiniteLength, HasLength, Map, Pointed, Show, TransitionSystem, Void, DFA,
@@ -59,13 +60,15 @@ impl<S: Symbol + Show> Show for ColoredClass<S, Void> {
     }
 }
 
-impl<A: Alphabet, Q: Clone + Show, C: Clone + Show> Debug for RightCongruence<A, Q, C> {
+impl<A: Alphabet, Q: Clone + Debug, C: Clone + Debug> Debug for RightCongruence<A, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
-            self.ts
-                .build_transition_table(|q, c| format!("{}|{}", q.show(), c.show()))
+            self.ts.build_transition_table(
+                |q, c| format!("{}|{:?}", q.show(), c),
+                |edge| edge.target().show()
+            )
         )
     }
 }

--- a/automata/src/random.rs
+++ b/automata/src/random.rs
@@ -1,6 +1,6 @@
 use tracing::{debug, info, trace};
 
-use crate::{prelude::*, Map};
+use crate::{prelude::*, Map, Void};
 
 /// Uses sprout-like algorithm to generate a random transition system. `symbols` determines the
 /// number of distinct symbols in the [`Simple`] alphabet. `probability` determines the probability
@@ -36,14 +36,14 @@ pub fn generate_random_ts(symbols: usize, probability: f64) -> Initialized<DTS> 
         for target in 0..=current {
             let value: f64 = fastrand::f64();
             if value < probability {
-                dts.add_edge(current, symbol, target, ());
+                dts.add_edge(current, symbol, target, Void);
                 continue 'outer;
             }
         }
 
         // no target was found so we create it
-        let target = dts.add_state(());
-        dts.add_edge(current, symbol, target, ());
+        let target = dts.add_state(Void);
+        dts.add_edge(current, symbol, target, Void);
     }
 
     dts.with_initial(0)

--- a/automata/src/ts/connected_components/mod.rs
+++ b/automata/src/ts/connected_components/mod.rs
@@ -95,7 +95,7 @@ mod tests {
             connected_components::{Scc, SccDecomposition},
             Sproutable,
         },
-        Pointed, RightCongruence, Set, TransitionSystem,
+        Pointed, RightCongruence, Set, TransitionSystem, Void,
     };
 
     use super::NTS;
@@ -106,14 +106,14 @@ mod tests {
         let q1 = cong.add_state(vec!['a']);
         let q2 = cong.add_state(vec!['b']);
         let q3 = cong.add_state(vec!['b', 'b']);
-        cong.add_edge(q0, 'a', q1, ());
-        cong.add_edge(q0, 'b', q2, ());
-        cong.add_edge(q1, 'a', q1, ());
-        cong.add_edge(q1, 'b', q1, ());
-        cong.add_edge(q2, 'a', q3, ());
-        cong.add_edge(q2, 'b', q2, ());
-        cong.add_edge(q3, 'a', q3, ());
-        cong.add_edge(q3, 'b', q2, ());
+        cong.add_edge(q0, 'a', q1, Void);
+        cong.add_edge(q0, 'b', q2, Void);
+        cong.add_edge(q1, 'a', q1, Void);
+        cong.add_edge(q1, 'b', q1, Void);
+        cong.add_edge(q2, 'a', q3, Void);
+        cong.add_edge(q2, 'b', q2, Void);
+        cong.add_edge(q3, 'a', q3, Void);
+        cong.add_edge(q3, 'b', q2, Void);
         cong
     }
 
@@ -133,15 +133,15 @@ mod tests {
 
         assert_eq!(
             scc2.interior_transitions(),
-            &Set::from_iter([(1, 'a', (), 1), (1, 'b', (), 1)])
+            &Set::from_iter([(1, 'a', Void, 1), (1, 'b', Void, 1)])
         );
         assert_eq!(
             scc3.interior_transitions(),
             &Set::from_iter([
-                (2, 'a', (), 3),
-                (2, 'b', (), 2),
-                (3, 'a', (), 3),
-                (3, 'b', (), 2)
+                (2, 'a', Void, 3),
+                (2, 'b', Void, 2),
+                (3, 'a', Void, 3),
+                (3, 'b', Void, 2)
             ])
         );
 

--- a/automata/src/ts/connected_components/scc.rs
+++ b/automata/src/ts/connected_components/scc.rs
@@ -1,4 +1,4 @@
-use std::{cell::OnceCell, collections::BTreeSet, fmt::Debug};
+use std::{cell::OnceCell, collections::BTreeSet, fmt::Debug, hash::Hash};
 
 use itertools::Itertools;
 
@@ -113,7 +113,10 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
     /// and target states are in the SCC itself.
     ///
     /// This is computed lazily and cached.
-    pub fn interior_edges(&self) -> &InteriorEdgeSet<Ts> {
+    pub fn interior_edges(&self) -> &InteriorEdgeSet<Ts>
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         self.edges.get_or_init(|| {
             let mut edges = Set::default();
             for q in &self.states {
@@ -133,7 +136,10 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
     /// and target states are in the SCC itself.
     ///
     /// This is computed lazily and cached.
-    pub fn interior_transitions(&self) -> &InteriorTransitionSet<Ts> {
+    pub fn interior_transitions(&self) -> &InteriorTransitionSet<Ts>
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         self.transitions.get_or_init(|| {
             let mut edges = Set::default();
             for q in &self.states {
@@ -169,7 +175,10 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
 
     /// Returns an iterator yielding the colors of edges whose source and target states are
     /// in the SCC.
-    pub fn interior_edge_colors(&self) -> &Set<Ts::EdgeColor> {
+    pub fn interior_edge_colors(&self) -> &Set<Ts::EdgeColor>
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         self.edge_colors.get_or_init(|| {
             self.interior_transitions()
                 .iter()
@@ -192,14 +201,20 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
     /// Attempts to compute a maximal word which is one that visits all states in the scc and uses
     /// each interior transition (one whose source and target are within the SCC) at least once.
     /// If no such word exists, `None` is returned.
-    pub fn maximal_word(&self) -> Option<Vec<SymbolOf<Ts>>> {
+    pub fn maximal_word(&self) -> Option<Vec<SymbolOf<Ts>>>
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         self.maximal_loop_from(*self.states.first()?)
     }
 
     /// Attempts to compute a maximal word (i.e. a word visiting all states in the scc). If such a
     /// word exists, it is returned, otherwise the function returns `None`.
     /// This ensures that the word ends back in the state that it started from.
-    pub fn maximal_loop_from(&self, from: Ts::StateIndex) -> Option<Vec<SymbolOf<Ts>>> {
+    pub fn maximal_loop_from(&self, from: Ts::StateIndex) -> Option<Vec<SymbolOf<Ts>>>
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         assert!(self.contains(&from));
         let ts = self.ts;
         debug_assert!(!self.is_empty());
@@ -295,13 +310,19 @@ impl<'a, Ts: TransitionSystem> Scc<'a, Ts> {
     }
 
     /// Returns `true` iff the SCC is left on every symbol of the alphabet.
-    pub fn is_transient(&self) -> bool {
+    pub fn is_transient(&self) -> bool
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         self.interior_transitions().is_empty()
     }
 
     /// Returns `true` iff there is a transition from a state in the SCC to another state in the SCC,
     /// i.e. if there is a way of reading a non-empty word and staying in the SCC.
-    pub fn is_nontransient(&self) -> bool {
+    pub fn is_nontransient(&self) -> bool
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         !self.interior_transitions().is_empty()
     }
 }

--- a/automata/src/ts/connected_components/tarjan_dag.rs
+++ b/automata/src/ts/connected_components/tarjan_dag.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use std::hash::Hash;
 
 use crate::{
     ts::{
@@ -8,7 +9,7 @@ use crate::{
     TransitionSystem,
 };
 
-use super::{Scc, SccDecomposition};
+use super::{EdgeColor, Scc, SccDecomposition};
 
 /// Newtype wrapper for storing indices of SCCs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -37,7 +38,10 @@ impl<'a, Ts: TransitionSystem> TarjanDAG<'a, Ts> {
     /// Returns an iterator over all transient states in the transition system. A state is transient
     /// if it is in a singleton SCC and there are no self loops. This means that from the state, there
     /// is no way to reach itself.
-    pub fn transient_states(&self) -> impl Iterator<Item = Ts::StateIndex> + '_ {
+    pub fn transient_states(&self) -> impl Iterator<Item = Ts::StateIndex> + '_
+    where
+        EdgeColor<Ts>: Hash + Eq,
+    {
         self.dag
             .nodes()
             .filter_map(|scc| {
@@ -85,6 +89,7 @@ impl<'a, Ts: TransitionSystem> TarjanDAG<'a, Ts> {
     where
         D: Clone,
         F: FnMut(D, &Ts::EdgeColor) -> D + Copy,
+        EdgeColor<Ts>: Hash + Eq,
     {
         self.dag
             .reduce(|x| x.interior_edge_colors().iter().fold(init.clone(), f))

--- a/automata/src/ts/dag.rs
+++ b/automata/src/ts/dag.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeSet, fmt::Debug};
 
 use itertools::Itertools;
 
-use crate::{ts::transition_system::IsEdge, Color, Set, TransitionSystem};
+use crate::{ts::transition_system::IsEdge, Color, Set, TransitionSystem, Void};
 
 use super::Index;
 
@@ -10,7 +10,7 @@ use super::Index;
 /// colored with some type `C`. The edges are represented as a vector of pairs
 /// of indices.
 #[derive(Clone)]
-pub struct Dag<C = ()> {
+pub struct Dag<C = Void> {
     nodes: Vec<C>,
     edges: Vec<(usize, usize)>,
 }

--- a/automata/src/ts/deterministic.rs
+++ b/automata/src/ts/deterministic.rs
@@ -447,10 +447,14 @@ pub trait Deterministic: TransitionSystem {
     }
 
     /// Returns a string representation of the transition table of the transition system.
-    fn build_transition_table<SD>(&self, state_decorator: SD) -> String
+    fn build_transition_table<'a, SD, ED>(
+        &'a self,
+        state_decorator: SD,
+        edge_decorator: ED,
+    ) -> String
     where
         SD: Fn(Self::StateIndex, StateColor<Self>) -> String,
-        (Self::StateIndex, EdgeColor<Self>): Show,
+        ED: Fn(Self::EdgeRef<'a>) -> String,
     {
         let mut builder = tabled::builder::Builder::default();
         builder.push_record(
@@ -468,7 +472,7 @@ pub trait Deterministic: TransitionSystem {
             )];
             for sym in self.alphabet().universe() {
                 if let Some(edge) = self.transition(id, sym) {
-                    row.push((edge.target(), edge.color()).show());
+                    row.push(edge_decorator(edge));
                 } else {
                     row.push("-".to_string());
                 }

--- a/automata/src/ts/dot.rs
+++ b/automata/src/ts/dot.rs
@@ -11,12 +11,13 @@ use crate::{
     prelude::{
         DPALike, IntoMealyMachine, IntoMooreMachine, MealyLike, MooreLike, Simple, Symbol, SymbolOf,
     },
+    ts::dot,
     Alphabet, Class, Color, Map, Pointed, RightCongruence, Show, TransitionSystem,
 };
 
 use super::{
     transition_system::{Indexes, IsEdge},
-    Deterministic, IndexType, BTS,
+    Deterministic, EdgeColor, ExpressionOf, IndexType, StateColor, BTS,
 };
 
 fn sanitize_dot_ident(name: &str) -> String {
@@ -39,7 +40,11 @@ fn sanitize_dot_ident(name: &str) -> String {
 pub trait Dottable: TransitionSystem {
     /// Compute the graphviz representation, for more information on the DOT format,
     /// see the [graphviz documentation](https://graphviz.org/doc/info/lang.html).
-    fn dot_representation(&self) -> String {
+    fn dot_representation<'a>(&'a self) -> String
+    where
+        (String, StateColor<Self>): Show,
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         let header = std::iter::once(format!(
             "digraph {} {{",
             self.dot_name().unwrap_or("A".to_string())
@@ -89,21 +94,31 @@ pub trait Dottable: TransitionSystem {
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = DotTransitionAttribute> {
+    ) -> impl IntoIterator<Item = DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         []
     }
     fn dot_state_ident(&self, idx: Self::StateIndex) -> String;
     fn dot_state_attributes(
         &self,
         idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = DotStateAttribute> {
+    ) -> impl IntoIterator<Item = DotStateAttribute>
+    where
+        (String, StateColor<Self>): Show,
+    {
         []
     }
     /// Renders the object visually (as PNG) and returns a vec of bytes/u8s encoding
     /// the rendered image. This method is only available on the `graphviz` crate feature
     /// and makes use of temporary files.
     #[cfg(feature = "graphviz")]
-    fn render(&self) -> Result<Vec<u8>, std::io::Error> {
+    fn render<'a>(&'a self) -> Result<Vec<u8>, std::io::Error>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+        (String, StateColor<Self>): Show,
+    {
         use std::io::{Read, Write};
 
         use tracing::trace;
@@ -139,7 +154,11 @@ pub trait Dottable: TransitionSystem {
     /// Attempts to render the object to a file with the given filename. This method
     /// is only available on the `graphviz` crate feature and makes use of temporary files.
     #[cfg(feature = "graphviz")]
-    fn render_to_file_name(&self, filename: &str) -> Result<(), std::io::Error> {
+    fn render_to_file_name<'a>(&'a self, filename: &str) -> Result<(), std::io::Error>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+        (String, StateColor<Self>): Show,
+    {
         use std::io::{Read, Write};
         use tracing::trace;
 
@@ -181,7 +200,11 @@ pub trait Dottable: TransitionSystem {
     /// can be configured by setting the `IMAGE_VIEWER` environment variable. If it is not set,
     /// then the display command of ImageMagick will be used.
     #[cfg(feature = "graphviz")]
-    fn display_rendered(&self) -> Result<(), std::io::Error> {
+    fn display_rendered<'a>(&'a self) -> Result<(), std::io::Error>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+        (String, StateColor<Self>): Show,
+    {
         display_png(self.render()?)?;
         Ok(())
     }
@@ -199,14 +222,20 @@ impl<A: Alphabet> Dottable for crate::DFA<A> {
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = DotTransitionAttribute> {
+    ) -> impl IntoIterator<Item = DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         [DotTransitionAttribute::Label(t.expression.show())].into_iter()
     }
 
     fn dot_state_attributes(
         &self,
         idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = DotStateAttribute> {
+    ) -> impl IntoIterator<Item = DotStateAttribute>
+    where
+        (String, StateColor<Self>): Show,
+    {
         let shape = if self.state_color(idx).unwrap() {
             "doublecircle"
         } else {
@@ -218,7 +247,7 @@ impl<A: Alphabet> Dottable for crate::DFA<A> {
         ]
     }
 }
-impl<A: Alphabet, Q: Color, C: Color> Dottable for crate::RightCongruence<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> Dottable for crate::RightCongruence<A, Q, C> {
     fn dot_name(&self) -> Option<String> {
         Some("Congruence".into())
     }
@@ -230,11 +259,13 @@ impl<A: Alphabet, Q: Color, C: Color> Dottable for crate::RightCongruence<A, Q, 
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = DotTransitionAttribute> {
+    ) -> impl IntoIterator<Item = DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         [DotTransitionAttribute::Label(format!(
-            "{}|{}",
-            t.expression.show(),
-            t.color.show()
+            "{}",
+            (t.expression(), t.color()).show()
         ))]
         .into_iter()
     }
@@ -242,16 +273,22 @@ impl<A: Alphabet, Q: Color, C: Color> Dottable for crate::RightCongruence<A, Q, 
     fn dot_state_attributes(
         &self,
         idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = DotStateAttribute> {
+    ) -> impl IntoIterator<Item = DotStateAttribute>
+    where
+        (String, StateColor<Self>): Show,
+    {
         vec![DotStateAttribute::Label(format!(
-            "{}|{}",
-            self.dot_state_ident(idx),
-            self.state_color(idx).unwrap().show()
+            "{}",
+            (self.dot_state_ident(idx), self.state_color(idx).unwrap()).show()
         ))]
     }
 }
 
-impl<M: MooreLike> Dottable for IntoMooreMachine<M> {
+impl<M> Dottable for IntoMooreMachine<M>
+where
+    M: MooreLike,
+    StateColor<M>: Color,
+{
     fn dot_name(&self) -> Option<String> {
         Some("DPA".into())
     }
@@ -259,7 +296,10 @@ impl<M: MooreLike> Dottable for IntoMooreMachine<M> {
     fn dot_state_attributes(
         &self,
         idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = DotStateAttribute> {
+    ) -> impl IntoIterator<Item = DotStateAttribute>
+    where
+        (String, StateColor<Self>): Show,
+    {
         let color = self
             .state_color(idx)
             .map(|c| format!(" | {}", c.show()))
@@ -273,7 +313,44 @@ impl<M: MooreLike> Dottable for IntoMooreMachine<M> {
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = DotTransitionAttribute> {
+    ) -> impl IntoIterator<Item = DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
+        vec![DotTransitionAttribute::Label(format!(
+            "{}",
+            t.expression().show(),
+        ))]
+    }
+
+    fn dot_state_ident(&self, idx: Self::StateIndex) -> String {
+        format!("q{}", idx.show())
+    }
+}
+
+impl<M> Dottable for IntoMealyMachine<M>
+where
+    M: MealyLike,
+    EdgeColor<M>: Show,
+{
+    fn dot_name(&self) -> Option<String> {
+        Some("DPA".into())
+    }
+
+    fn dot_state_attributes(
+        &self,
+        idx: Self::StateIndex,
+    ) -> impl IntoIterator<Item = DotStateAttribute> {
+        vec![DotStateAttribute::Label(self.dot_state_ident(idx))]
+    }
+
+    fn dot_transition_attributes<'a>(
+        &'a self,
+        t: Self::EdgeRef<'a>,
+    ) -> impl IntoIterator<Item = DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         vec![DotTransitionAttribute::Label(format!(
             "{}|{}",
             t.expression().show(),
@@ -286,7 +363,10 @@ impl<M: MooreLike> Dottable for IntoMooreMachine<M> {
     }
 }
 
-impl<M: MealyLike> Dottable for IntoMealyMachine<M> {
+impl<D: DPALike> Dottable for IntoDPA<D>
+where
+    EdgeColor<D>: Show,
+{
     fn dot_name(&self) -> Option<String> {
         Some("DPA".into())
     }
@@ -295,55 +375,16 @@ impl<M: MealyLike> Dottable for IntoMealyMachine<M> {
         &self,
         idx: Self::StateIndex,
     ) -> impl IntoIterator<Item = DotStateAttribute> {
-        let color = self
-            .state_color(idx)
-            .map(|c| format!(" | {}", c.show()))
-            .unwrap_or("".to_string());
-        vec![DotStateAttribute::Label(format!(
-            "{}{color}",
-            self.dot_state_ident(idx)
-        ))]
+        vec![DotStateAttribute::Label(self.dot_state_ident(idx))]
     }
 
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = DotTransitionAttribute> {
-        vec![DotTransitionAttribute::Label(format!(
-            "{}|{}",
-            t.expression().show(),
-            t.color().show()
-        ))]
-    }
-
-    fn dot_state_ident(&self, idx: Self::StateIndex) -> String {
-        format!("q{}", idx.show())
-    }
-}
-
-impl<D: DPALike> Dottable for IntoDPA<D> {
-    fn dot_name(&self) -> Option<String> {
-        Some("DPA".into())
-    }
-
-    fn dot_state_attributes(
-        &self,
-        idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = DotStateAttribute> {
-        let color = self
-            .state_color(idx)
-            .map(|c| format!(" | {}", c.show()))
-            .unwrap_or("".to_string());
-        vec![DotStateAttribute::Label(format!(
-            "{}{color}",
-            self.dot_state_ident(idx)
-        ))]
-    }
-
-    fn dot_transition_attributes<'a>(
-        &'a self,
-        t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = DotTransitionAttribute> {
+    ) -> impl IntoIterator<Item = DotTransitionAttribute>
+    where
+        (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
+    {
         vec![DotTransitionAttribute::Label(format!(
             "{}|{}",
             t.expression().show(),
@@ -612,7 +653,7 @@ mod tests {
         congruence::FORC,
         prelude::DPA,
         ts::{Sproutable, NTS},
-        Class, Pointed, RightCongruence,
+        Class, Pointed, RightCongruence, Void,
     };
 
     use super::Dottable;
@@ -622,10 +663,10 @@ mod tests {
     fn render_dfa() {
         let dfa = NTS::builder()
             .with_transitions([
-                (0, 'a', (), 0),
-                (0, 'b', (), 1),
-                (1, 'a', (), 1),
-                (1, 'b', (), 0),
+                (0, 'a', Void, 0),
+                (0, 'b', Void, 1),
+                (1, 'a', Void, 1),
+                (1, 'b', Void, 0),
             ])
             .with_colors([false, true])
             .into_dfa(0);
@@ -639,35 +680,35 @@ mod tests {
         let mut cong = RightCongruence::new(alphabet.clone());
         let q0 = cong.initial();
         let q1 = cong.add_state(vec!['a']);
-        cong.add_edge(q0, 'a', q1, ());
-        cong.add_edge(q0, 'b', q0, ());
-        cong.add_edge(q1, 'a', q0, ());
-        cong.add_edge(q1, 'b', q1, ());
+        cong.add_edge(q0, 'a', q1, Void);
+        cong.add_edge(q0, 'b', q0, Void);
+        cong.add_edge(q1, 'a', q0, Void);
+        cong.add_edge(q1, 'b', q1, Void);
 
         let mut prc_e = RightCongruence::new(alphabet.clone());
         let e0 = prc_e.initial();
         let e1 = prc_e.add_state(vec!['a']);
         let e2 = prc_e.add_state(vec!['b']);
-        prc_e.add_edge(e0, 'a', e1, ());
-        prc_e.add_edge(e0, 'b', e2, ());
-        prc_e.add_edge(e1, 'a', e1, ());
-        prc_e.add_edge(e1, 'b', e2, ());
-        prc_e.add_edge(e2, 'a', e2, ());
-        prc_e.add_edge(e2, 'b', e2, ());
+        prc_e.add_edge(e0, 'a', e1, Void);
+        prc_e.add_edge(e0, 'b', e2, Void);
+        prc_e.add_edge(e1, 'a', e1, Void);
+        prc_e.add_edge(e1, 'b', e2, Void);
+        prc_e.add_edge(e2, 'a', e2, Void);
+        prc_e.add_edge(e2, 'b', e2, Void);
 
         let mut prc_a = RightCongruence::new(alphabet);
         let a0 = prc_a.initial();
         let a1 = prc_a.add_state(vec!['a']);
         let a2 = prc_a.add_state(vec!['b']);
         let a3 = prc_a.add_state(vec!['a', 'a']);
-        prc_a.add_edge(a0, 'a', a1, ());
-        prc_a.add_edge(a0, 'b', a2, ());
-        prc_a.add_edge(a1, 'a', a3, ());
-        prc_a.add_edge(a1, 'b', a2, ());
-        prc_a.add_edge(a2, 'a', a1, ());
-        prc_a.add_edge(a2, 'b', a2, ());
-        prc_a.add_edge(a3, 'a', a3, ());
-        prc_a.add_edge(a3, 'b', a3, ());
+        prc_a.add_edge(a0, 'a', a1, Void);
+        prc_a.add_edge(a0, 'b', a2, Void);
+        prc_a.add_edge(a1, 'a', a3, Void);
+        prc_a.add_edge(a1, 'b', a2, Void);
+        prc_a.add_edge(a2, 'a', a1, Void);
+        prc_a.add_edge(a2, 'b', a2, Void);
+        prc_a.add_edge(a3, 'a', a3, Void);
+        prc_a.add_edge(a3, 'b', a3, Void);
 
         let forc = FORC::from_iter(cong, [(0, prc_e), (1, prc_a)].iter().cloned());
         todo!()
@@ -681,10 +722,10 @@ mod tests {
         let mut cong = RightCongruence::new(alphabet);
         let q0 = cong.initial();
         let q1 = cong.add_state(vec!['a']);
-        cong.add_edge(q0, 'a', q1, ());
-        cong.add_edge(q0, 'b', q0, ());
-        cong.add_edge(q1, 'a', q0, ());
-        cong.add_edge(q1, 'b', q1, ());
+        cong.add_edge(q0, 'a', q1, Void);
+        cong.add_edge(q0, 'b', q0, Void);
+        cong.add_edge(q1, 'a', q0, Void);
+        cong.add_edge(q1, 'b', q1, Void);
 
         cong.display_rendered();
         let three_congs = vec![cong.clone(), cong.clone(), cong];

--- a/automata/src/ts/dot.rs
+++ b/automata/src/ts/dot.rs
@@ -263,10 +263,9 @@ impl<A: Alphabet, Q: Clone, C: Clone> Dottable for crate::RightCongruence<A, Q, 
     where
         (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
     {
-        [DotTransitionAttribute::Label(format!(
-            "{}",
-            (t.expression(), t.color()).show()
-        ))]
+        [DotTransitionAttribute::Label(
+            (t.expression(), t.color()).show(),
+        )]
         .into_iter()
     }
 
@@ -277,10 +276,9 @@ impl<A: Alphabet, Q: Clone, C: Clone> Dottable for crate::RightCongruence<A, Q, 
     where
         (String, StateColor<Self>): Show,
     {
-        vec![DotStateAttribute::Label(format!(
-            "{}",
-            (self.dot_state_ident(idx), self.state_color(idx).unwrap()).show()
-        ))]
+        vec![DotStateAttribute::Label(
+            (self.dot_state_ident(idx), self.state_color(idx).unwrap()).show(),
+        )]
     }
 }
 
@@ -317,10 +315,7 @@ where
     where
         (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
     {
-        vec![DotTransitionAttribute::Label(format!(
-            "{}",
-            t.expression().show(),
-        ))]
+        vec![DotTransitionAttribute::Label(t.expression().show())]
     }
 
     fn dot_state_ident(&self, idx: Self::StateIndex) -> String {

--- a/automata/src/ts/dts.rs
+++ b/automata/src/ts/dts.rs
@@ -1,11 +1,11 @@
-use crate::prelude::*;
+use crate::{prelude::*, Void};
 
 use super::nts::{NTEdge, NTSEdgesFromIter, NTSEdgesTo};
 
 /// A deterministic transition system. This is a thin wrapper around [`NTS`] and is only used to
 /// enforce that the underlying NTS is deterministic.
 #[derive(Clone, Eq, PartialEq)]
-pub struct DTS<A: Alphabet = Simple, Q = NoColor, C = NoColor>(pub(crate) NTS<A, Q, C>);
+pub struct DTS<A: Alphabet = Simple, Q = Void, C = Void>(pub(crate) NTS<A, Q, C>);
 
 /// Type alias to create a deterministic transition with the same alphabet, state and edge color
 /// as the given [`Ts`](`crate::prelude::TransitionSystem`).
@@ -15,7 +15,7 @@ pub type CollectDTS<Ts> = DTS<
     <Ts as TransitionSystem>::EdgeColor,
 >;
 
-impl<A: Alphabet, Q: Color, C: Color> TryFrom<NTS<A, Q, C>> for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> TryFrom<NTS<A, Q, C>> for DTS<A, Q, C> {
     type Error = ();
 
     fn try_from(value: NTS<A, Q, C>) -> Result<Self, Self::Error> {
@@ -26,7 +26,7 @@ impl<A: Alphabet, Q: Color, C: Color> TryFrom<NTS<A, Q, C>> for DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> TryFrom<Initialized<NTS<A, Q, C>>>
+impl<A: Alphabet, Q: Clone, C: Clone> TryFrom<Initialized<NTS<A, Q, C>>>
     for Initialized<DTS<A, Q, C>>
 {
     /// Only fails if nts is not deterministic.
@@ -38,7 +38,7 @@ impl<A: Alphabet, Q: Color, C: Color> TryFrom<Initialized<NTS<A, Q, C>>>
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> TryFrom<&NTS<A, Q, C>> for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> TryFrom<&NTS<A, Q, C>> for DTS<A, Q, C> {
     type Error = ();
 
     fn try_from(value: &NTS<A, Q, C>) -> Result<Self, Self::Error> {
@@ -49,7 +49,7 @@ impl<A: Alphabet, Q: Color, C: Color> TryFrom<&NTS<A, Q, C>> for DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> TryFrom<&Initialized<NTS<A, Q, C>>>
+impl<A: Alphabet, Q: Clone, C: Clone> TryFrom<&Initialized<NTS<A, Q, C>>>
     for Initialized<DTS<A, Q, C>>
 {
     /// Only fails if nts is not deterministic.
@@ -61,13 +61,13 @@ impl<A: Alphabet, Q: Color, C: Color> TryFrom<&Initialized<NTS<A, Q, C>>>
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> From<DTS<A, Q, C>> for NTS<A, Q, C> {
+impl<A: Alphabet, Q, C> From<DTS<A, Q, C>> for NTS<A, Q, C> {
     fn from(value: DTS<A, Q, C>) -> Self {
         value.0
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> TransitionSystem for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for DTS<A, Q, C> {
     type StateIndex = usize;
 
     type StateColor = Q;
@@ -105,9 +105,9 @@ impl<A: Alphabet, Q: Color, C: Color> TransitionSystem for DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Deterministic for DTS<A, Q, C> {}
+impl<A: Alphabet, Q: Clone, C: Clone> Deterministic for DTS<A, Q, C> {}
 
-impl<A: Alphabet, Q: Color, C: Color> PredecessorIterable for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> PredecessorIterable for DTS<A, Q, C> {
     type PreEdgeRef<'this> = &'this NTEdge<A::Expression, C>
     where
         Self: 'this;
@@ -121,7 +121,7 @@ impl<A: Alphabet, Q: Color, C: Color> PredecessorIterable for DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> Sproutable for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for DTS<A, Q, C> {
     fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
         Self(NTS::new_for_alphabet(alphabet))
     }
@@ -170,14 +170,14 @@ impl<A: Alphabet, Q: Color, C: Color> Sproutable for DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone, C: Clone> DTS<A, Q, C> {
     /// Creates an empty [`DTS`] with the given alphabet and capacity for at least `cap` states.
     pub fn with_capacity(alphabet: A, cap: usize) -> Self {
         Self(NTS::with_capacity(alphabet, cap))
     }
 }
 
-impl<A: Alphabet, Q: Color, C: Color> std::fmt::Debug for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone + Show, C: Clone + Show> std::fmt::Debug for DTS<A, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/automata/src/ts/dts.rs
+++ b/automata/src/ts/dts.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::{prelude::*, Void};
 
 use super::nts::{NTEdge, NTSEdgesFromIter, NTSEdgesTo};
@@ -177,12 +179,15 @@ impl<A: Alphabet, Q: Clone, C: Clone> DTS<A, Q, C> {
     }
 }
 
-impl<A: Alphabet, Q: Clone + Show, C: Clone + Show> std::fmt::Debug for DTS<A, Q, C> {
+impl<A: Alphabet, Q: Clone + Debug, C: Clone + Debug> std::fmt::Debug for DTS<A, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
-            self.build_transition_table(|q, c| format!("{}|{}", q.show(), c.show()))
+            self.build_transition_table(
+                |q, c| format!("{q}|{c:?}"),
+                |edge| format!("{:?}->{}", edge.color(), edge.target())
+            )
         )
     }
 }

--- a/automata/src/ts/index_ts.rs
+++ b/automata/src/ts/index_ts.rs
@@ -1,8 +1,13 @@
-use std::hash::Hash;
+use std::{fmt::Debug, hash::Hash};
 
 use itertools::Itertools;
 
-use crate::{alphabet::Alphabet, prelude::Initialized, ts::Deterministic, Color, Map, Set, Show};
+use crate::{
+    alphabet::Alphabet,
+    prelude::Initialized,
+    ts::{transition_system::IsEdge, Deterministic},
+    Color, Map, Set, Show,
+};
 
 use super::{
     EdgeColor, ExpressionOf, HasColor, HasColorMut, HasMutableStates, HasStates, IndexType,
@@ -120,15 +125,18 @@ pub type IntoInitialBTS<Ts> = Initialized<
 impl<A, C, Q, Idx> std::fmt::Debug for BTS<A, Q, C, Idx>
 where
     A: Alphabet,
-    C: Color + Show,
-    Q: Color + Show,
+    C: Debug + Clone + Hash + Eq,
+    Q: Debug + Clone + Hash + Eq,
     Idx: IndexType,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
             "{}",
-            self.build_transition_table(|idx, c| format!("{} : {}", idx, c.show()))
+            self.build_transition_table(
+                |idx, c| format!("{} : {:?}", idx, c),
+                |edge| format!("{:?}->{}", edge.color(), edge.target())
+            )
         )
     }
 }

--- a/automata/src/ts/mod.rs
+++ b/automata/src/ts/mod.rs
@@ -10,7 +10,7 @@ pub use transition_system::{DeterministicEdgesFrom, ExpressionOf, SymbolOf, Tran
 /// Defines implementations for common operations on automata/transition systems.
 pub mod operations;
 
-use crate::{Class, Color, Map, RightCongruence, Show};
+use crate::{Class, Color, Map, RightCongruence, Show, Void};
 
 mod index_ts;
 pub use index_ts::{IntoBTS, IntoInitialBTS, BTS};
@@ -246,7 +246,8 @@ pub trait Congruence: Deterministic + Pointed {
         RightCongruence<Self::Alphabet>,
         Map<Self::StateIndex, usize>,
     ) {
-        let mut cong = RightCongruence::new_for_alphabet(self.alphabet().clone());
+        let mut cong: RightCongruence<Self::Alphabet> =
+            RightCongruence::new_for_alphabet(self.alphabet().clone());
         let mut map = Map::default();
 
         for state in self.state_indices() {
@@ -263,7 +264,7 @@ pub trait Congruence: Deterministic + Pointed {
                         *map.get(&state).unwrap(),
                         edge.expression().clone(),
                         *target_class,
-                        (),
+                        Void,
                     );
                 }
             }

--- a/automata/src/ts/operations/map.rs
+++ b/automata/src/ts/operations/map.rs
@@ -21,8 +21,8 @@ pub struct MappedPreEdge<Idx, T, F, C> {
 impl<'a, Idx, E: 'a, C, D, F, T> IsEdge<'a, E, Idx, D> for MappedPreEdge<Idx, T, F, C>
 where
     Idx: IndexType,
-    C: Color,
-    D: Color,
+    C: Clone,
+    D: Clone,
     F: Fn(Idx, &E, C, Idx) -> D,
     T: IsEdge<'a, E, Idx, C>,
 {
@@ -76,7 +76,7 @@ where
 
 impl<Ts, D, F> PredecessorIterable for MapEdges<Ts, F>
 where
-    D: Color,
+    D: Clone,
     Ts: PredecessorIterable,
     F: Fn(Ts::StateIndex, &ExpressionOf<Ts>, Ts::EdgeColor, Ts::StateIndex) -> D,
 {
@@ -139,8 +139,8 @@ impl<Idx, T, F, C> MappedEdge<Idx, T, F, C> {
 impl<'ts, Idx, E: 'ts, C, D, F, T> IsEdge<'ts, E, Idx, D> for MappedEdge<Idx, T, F, C>
 where
     Idx: IndexType,
-    C: Color,
-    D: Color,
+    C: Clone,
+    D: Clone,
     F: Fn(Idx, &E, C, Idx) -> D,
     T: IsEdge<'ts, E, Idx, C>,
 {
@@ -169,7 +169,7 @@ where
 impl<Ts, D, F> TransitionSystem for MapEdges<Ts, F>
 where
     Ts: TransitionSystem,
-    D: Color,
+    D: Clone,
     F: Fn(Ts::StateIndex, &ExpressionOf<Ts>, Ts::EdgeColor, Ts::StateIndex) -> D,
 {
     type StateIndex = Ts::StateIndex;
@@ -233,7 +233,7 @@ impl<Ts, F> MapEdges<Ts, F> {
 }
 impl<D, Ts, F> Pointed for MapEdges<Ts, F>
 where
-    D: Color,
+    D: Clone,
     Ts: TransitionSystem + Pointed,
     F: Fn(Ts::StateIndex, &ExpressionOf<Ts>, Ts::EdgeColor, Ts::StateIndex) -> D,
 {
@@ -264,7 +264,7 @@ impl<Ts, F> MapEdgeColor<Ts, F> {
     }
 }
 
-impl<D: Color, Ts: TransitionSystem + Pointed, F: Fn(Ts::EdgeColor) -> D> Pointed
+impl<D: Clone, Ts: TransitionSystem + Pointed, F: Fn(Ts::EdgeColor) -> D> Pointed
     for MapEdgeColor<Ts, F>
 {
     fn initial(&self) -> Self::StateIndex {
@@ -294,8 +294,8 @@ impl<T, F, C> MappedTransition<T, F, C> {
 impl<'ts, Idx, E, C, D, F, T> IsEdge<'ts, E, Idx, D> for MappedTransition<T, F, C>
 where
     Idx: IndexType,
-    C: Color,
-    D: Color,
+    C: Clone,
+    D: Clone,
     F: Fn(C) -> D,
     T: IsEdge<'ts, E, Idx, C>,
 {
@@ -354,9 +354,9 @@ pub struct MappedPreTransition<T, F, C> {
     _old_color: PhantomData<C>,
 }
 
-// impl<Idx: IndexType, E, C: Color, D: Color, F: Fn(C) -> D, T: IsTransition<E, Idx, C>>
+// impl<Idx: IndexType, E, C: Clone, D: Clone, F: Fn(C) -> D, T: IsTransition<E, Idx, C>>
 // IsTransition<E, Idx, D> for MappedTransition<T, F, C>
-impl<'a, Idx: IndexType, E, C: Color, D: Color, F: Fn(C) -> D, T: IsEdge<'a, E, Idx, C>>
+impl<'a, Idx: IndexType, E, C: Clone, D: Clone, F: Fn(C) -> D, T: IsEdge<'a, E, Idx, C>>
     IsEdge<'a, E, Idx, D> for MappedPreTransition<T, F, C>
 {
     fn source(&self) -> Idx {
@@ -438,7 +438,7 @@ impl<Ts, F> MapStateColor<Ts, F> {
     }
 }
 
-impl<D: Color, Ts: TransitionSystem + Pointed, F: Fn(Ts::StateColor) -> D> Pointed
+impl<D: Clone, Ts: TransitionSystem + Pointed, F: Fn(Ts::StateColor) -> D> Pointed
     for MapStateColor<Ts, F>
 {
     fn initial(&self) -> Self::StateIndex {

--- a/automata/src/ts/operations/product.rs
+++ b/automata/src/ts/operations/product.rs
@@ -146,10 +146,10 @@ impl<'a, LI, RI, E, LC, RC> ProductTransition<'a, LI, RI, E, LC, RC> {
 impl<'a, Idx, Jdx, E, C, D> IsEdge<'a, E, ProductIndex<Idx, Jdx>, (C, D)>
     for ProductTransition<'a, Idx, Jdx, E, C, D>
 where
+    C: Clone,
+    D: Clone,
     Idx: IndexType,
     Jdx: IndexType,
-    C: Color,
-    D: Color,
 {
     fn source(&self) -> ProductIndex<Idx, Jdx> {
         ProductIndex(self.source.0, self.source.1)

--- a/automata/src/ts/operations/restricted.rs
+++ b/automata/src/ts/operations/restricted.rs
@@ -175,13 +175,19 @@ pub struct ColorRestricted<D: TransitionSystem> {
     max: D::EdgeColor,
 }
 
-impl<D: TransitionSystem + Pointed> Pointed for ColorRestricted<D> {
+impl<D: Congruence> Pointed for ColorRestricted<D>
+where
+    EdgeColor<D>: Ord,
+{
     fn initial(&self) -> Self::StateIndex {
         self.ts.initial()
     }
 }
 
-impl<D: TransitionSystem> TransitionSystem for ColorRestricted<D> {
+impl<D: TransitionSystem> TransitionSystem for ColorRestricted<D>
+where
+    EdgeColor<D>: Ord,
+{
     type StateIndex = D::StateIndex;
 
     type StateColor = D::StateColor;
@@ -265,7 +271,10 @@ pub struct ColorRestrictedEdgesFrom<'a, D: TransitionSystem> {
     max: D::EdgeColor,
 }
 
-impl<'a, D: TransitionSystem> Iterator for ColorRestrictedEdgesFrom<'a, D> {
+impl<'a, D: TransitionSystem> Iterator for ColorRestrictedEdgesFrom<'a, D>
+where
+    EdgeColor<D>: Ord,
+{
     type Item = D::EdgeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -283,7 +292,10 @@ pub struct ColorRestrictedEdgesTo<'a, D: PredecessorIterable> {
     max: D::EdgeColor,
 }
 
-impl<'a, D: PredecessorIterable> Iterator for ColorRestrictedEdgesTo<'a, D> {
+impl<'a, D: PredecessorIterable> Iterator for ColorRestrictedEdgesTo<'a, D>
+where
+    EdgeColor<D>: Ord,
+{
     type Item = D::PreEdgeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -161,22 +161,25 @@ impl<Ts: TransitionSystem> TransitionSystem for SubsetConstruction<Ts> {
 
 impl<Ts: TransitionSystem> Debug for SubsetConstruction<Ts>
 where
-    EdgeColor<Ts>: Show,
+    EdgeColor<Ts>: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Subset construction\n{}",
-            self.build_transition_table(|idx, _| format!(
-                "{{{}}}",
-                self.states
-                    .borrow()
-                    .get(idx)
-                    .unwrap()
-                    .iter()
-                    .map(|q| q.to_string())
-                    .join(", ")
-            ))
+            self.build_transition_table(
+                |idx, _| format!(
+                    "{{{}}}",
+                    self.states
+                        .borrow()
+                        .get(idx)
+                        .unwrap()
+                        .iter()
+                        .map(|q| q.to_string())
+                        .join(", ")
+                ),
+                |edge| edge.target().to_string()
+            )
         )
     }
 }

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -147,19 +147,22 @@ impl<Ts: TransitionSystem> TransitionSystem for SubsetConstruction<Ts> {
             q.iter()
                 .map(|idx| {
                     let Some(color) = self.ts.state_color(*idx) else {
-                        panic!("Could not find state {} in ts {:?}", state, self);
+                        panic!("Could not find state {}", state);
                     };
                     color
                 })
                 .collect()
         }) else {
-            panic!("Could not find state {} in ts {:?}", state, self);
+            panic!("Could not find state {}", state);
         };
         Some(color)
     }
 }
 
-impl<Ts: TransitionSystem> Debug for SubsetConstruction<Ts> {
+impl<Ts: TransitionSystem> Debug for SubsetConstruction<Ts>
+where
+    EdgeColor<Ts>: Show,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/automata/src/ts/path.rs
+++ b/automata/src/ts/path.rs
@@ -33,7 +33,7 @@ pub type PathIn<D> = Path<
     <D as TransitionSystem>::EdgeColor,
 >;
 
-impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
+impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone> Path<A, Idx, Q, C> {
     /// Builds a new path from its parts, which are the index of the state it ends in, the sequence of
     /// state colors and the setquence of transitions.
     pub fn from_parts(
@@ -205,13 +205,13 @@ impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Path<A, Idx, Q, C> {
     }
 }
 
-impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Debug for Path<A, Idx, Q, C> {
+impl<A: Alphabet, Idx: IndexType, Q: Show, C: Show> Debug for Path<A, Idx, Q, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.show())
     }
 }
 
-impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Show for Path<A, Idx, Q, C> {
+impl<A: Alphabet, Idx: IndexType, Q: Show, C: Show> Show for Path<A, Idx, Q, C> {
     fn show(&self) -> String {
         format!(
             "{}{}",
@@ -239,7 +239,7 @@ pub type LassoIn<D> = Lasso<
     <D as TransitionSystem>::EdgeColor,
 >;
 
-impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> Lasso<A, Idx, Q, C> {
+impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone> Lasso<A, Idx, Q, C> {
     /// Creates a new [`Lasso`] from the given base/spoke and cycle/recurring [`Path`].
     pub fn new(base: Path<A, Idx, Q, C>, cycle: Path<A, Idx, Q, C>) -> Self {
         Self { base, cycle }

--- a/automata/src/ts/predecessors.rs
+++ b/automata/src/ts/predecessors.rs
@@ -1,6 +1,6 @@
 use impl_tools::autoimpl;
 
-use crate::{automaton::Initialized, Alphabet, Color, RightCongruence, TransitionSystem};
+use crate::{automaton::Initialized, Alphabet, Color, RightCongruence, TransitionSystem, Void};
 
 use super::{
     nts::{NTEdge, NTSEdgesTo},
@@ -150,11 +150,11 @@ impl<'a, A: Alphabet, C: Color, Idx: IndexType> BTSPredecessors<'a, A, C, Idx> {
 }
 
 impl<A: Alphabet> PredecessorIterable for RightCongruence<A> {
-    type PreEdgeRef<'this> = &'this NTEdge<A::Expression, ()>
+    type PreEdgeRef<'this> = &'this NTEdge<A::Expression, Void>
     where
         Self: 'this;
 
-    type EdgesToIter<'this> = NTSEdgesTo<'this, A::Expression, ()>
+    type EdgesToIter<'this> = NTSEdgesTo<'this, A::Expression, Void>
     where
         Self: 'this;
     fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {

--- a/automata/src/ts/run/successful.rs
+++ b/automata/src/ts/run/successful.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeSet;
 
-use crate::ts::{
-    finite::{InfinityColors, ReachedColor, ReachedState, SeenColors, TransitionColorSequence},
-    infinite::InfinityStateColors,
-    path::PathIn,
-    CanInduce, Deterministic, Path,
+use crate::{
+    ts::{
+        finite::{InfinityColors, ReachedColor, ReachedState, SeenColors, TransitionColorSequence},
+        infinite::InfinityStateColors,
+        path::PathIn,
+        CanInduce, Deterministic, EdgeColor, Path,
+    },
+    Color,
 };
 
 use crate::ts::TransitionSystem;
@@ -35,7 +38,7 @@ impl<R, Ts: Deterministic> Successful<R, Ts> {
 impl<R, Ts> CanInduce<SeenColors<Ts::StateColor>> for Successful<R, Ts>
 where
     Ts: Deterministic,
-    Ts::StateColor: Clone,
+    Ts::StateColor: Color,
 {
     fn induce(&self) -> SeenColors<Ts::StateColor> {
         SeenColors(self.path.state_colors().cloned().collect())
@@ -45,7 +48,7 @@ where
 impl<R, Ts> CanInduce<InfinityColors<Ts::EdgeColor>> for Successful<R, Ts>
 where
     Ts: Deterministic,
-    Ts::StateColor: Clone,
+    EdgeColor<Ts>: Color,
 {
     fn induce(&self) -> InfinityColors<Ts::EdgeColor> {
         InfinityColors(self.path.edge_colors().cloned().collect())
@@ -55,7 +58,7 @@ where
 impl<R, Ts> CanInduce<InfinityStateColors<Ts::StateColor>> for Successful<R, Ts>
 where
     Ts: Deterministic,
-    Ts::StateColor: Clone,
+    Ts::StateColor: Color,
 {
     fn induce(&self) -> InfinityStateColors<Ts::StateColor> {
         let state_colors: BTreeSet<_> = self
@@ -72,7 +75,7 @@ where
 impl<R, Ts> CanInduce<ReachedColor<Ts::StateColor>> for Successful<R, Ts>
 where
     Ts: Deterministic,
-    Ts::StateColor: Clone,
+    Ts::StateColor: Color,
 {
     fn induce(&self) -> ReachedColor<Ts::StateColor> {
         ReachedColor(self.path.reached_state_color())
@@ -85,7 +88,10 @@ impl<R, Ts: Deterministic> CanInduce<ReachedState<Ts::StateIndex>> for Successfu
     }
 }
 
-impl<R, Ts: Deterministic> CanInduce<TransitionColorSequence<Ts::EdgeColor>> for Successful<R, Ts> {
+impl<R, Ts: Deterministic> CanInduce<TransitionColorSequence<Ts::EdgeColor>> for Successful<R, Ts>
+where
+    EdgeColor<Ts>: Color,
+{
     fn induce(&self) -> TransitionColorSequence<Ts::EdgeColor> {
         TransitionColorSequence(self.path.edge_colors().cloned().collect())
     }

--- a/automata/src/ts/shrinkable.rs
+++ b/automata/src/ts/shrinkable.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use crate::{automaton::Initialized, Alphabet, Color, Set, TransitionSystem};
 
 use super::{transition_system::Indexes, ExpressionOf, IndexType, SymbolOf, BTS, DTS, NTS};
@@ -31,7 +33,9 @@ pub trait Shrinkable: TransitionSystem {
     ) -> Option<Set<(ExpressionOf<Self>, Self::EdgeColor, Self::StateIndex)>>;
 }
 
-impl<A: Alphabet, Q: Color, C: Color, Index: IndexType> Shrinkable for BTS<A, Q, C, Index> {
+impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq, Index: IndexType> Shrinkable
+    for BTS<A, Q, C, Index>
+{
     fn remove_state<Idx: Indexes<Self>>(&mut self, state: Idx) -> Option<Self::StateColor> {
         self.bts_remove_state(state.to_index(self)?)
     }

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -168,7 +168,6 @@ mod tests {
             .deterministic();
         assert_eq!(partial.reached_state_index_from("aaacb", 0), None);
         partial.complete_with_colors((), 2);
-        println!("{}", partial.build_transition_table(|q, c| format!("{q}")));
         for w in ["abbaccababcab", "bbcca", "cc", "aababbabbabbccbabba"] {
             if partial.reached_state_index_from(w, 0).unwrap() < 1 {
                 panic!("Word {} misclassified", w);


### PR DESCRIPTION
This implements the `Void` type mentioned in #46 .

As a consequence, the trait bounds of most automata types have moved further out of the library core. This means that the underlying implementations `BTS` and `HashTS` only assume a minimum of bounds on the type of state and edge colors `Q` and `C` respectively. This means that the `MooreLike` and `MealyLike` traits have pretty much become useless, as they still require the user to specify a bound on the edges.

This will be addressed, once #35 is tackled since a better (unifying) `Automaton` type will allow Moore and Mealy machines to be simple type aliases for some specific instantiation of `Automaton`.