### PR TITLE
Specialize and rework collection of transition systems

### DIFF
--- a/automata-learning/src/passive/mod.rs
+++ b/automata-learning/src/passive/mod.rs
@@ -52,6 +52,7 @@ pub fn dfa_rpni<A: Alphabet>(sample: &FiniteSample<A, bool>) -> DFA<A> {
             accepting.contains(&idx)
         })
         .collect_pointed()
+        .0
         .into_dfa()
 }
 

--- a/automata-learning/src/passive/mod.rs
+++ b/automata-learning/src/passive/mod.rs
@@ -52,6 +52,7 @@ pub fn dfa_rpni<A: Alphabet>(sample: &FiniteSample<A, bool>) -> DFA<A> {
             accepting.contains(&idx)
         })
         .collect_pointed()
+        .into_dfa()
 }
 
 /// Executes a variant of the RPNI algorithm for omega-words, producing a DBA.

--- a/automata-learning/src/priority_mapping.rs
+++ b/automata-learning/src/priority_mapping.rs
@@ -168,6 +168,7 @@ impl<A: Alphabet> AnnotatedCongruence<A> {
                 info.expect("Every SCC must have a color")
             })
             .collect_pointed()
+            .0
             .into_moore()
     }
 
@@ -190,7 +191,8 @@ impl<A: Alphabet> AnnotatedCongruence<A> {
                     Annotation::new(false, None)
                 }
             })
-            .collect_pointed::<DTS<_, Annotation, Void>>();
+            .collect_pointed::<DTS<_, Annotation, Void>>()
+            .0;
         let rc = RightCongruence::from_ts(cong);
         Self::new(rc)
     }

--- a/automata-learning/src/priority_mapping.rs
+++ b/automata-learning/src/priority_mapping.rs
@@ -5,6 +5,7 @@ use owo_colors::OwoColorize;
 
 use automata::{
     automaton::MooreLike,
+    congruence::ColoredClass,
     prelude::*,
     ts::dot::{DotStateAttribute, Dottable},
     Set,
@@ -93,6 +94,12 @@ impl Annotation {
 #[derive(Clone)]
 pub struct AnnotatedCongruence<A: Alphabet = Simple>(RightCongruence<A, Annotation, Void>);
 
+impl<A: Alphabet> AnnotatedCongruence<A> {
+    pub fn new(rc: RightCongruence<A, Annotation, Void>) -> Self {
+        Self(rc)
+    }
+}
+
 #[autoimpl(for<T: trait + ?Sized> &T)]
 pub trait ClassifiesIdempotents<A: Alphabet> {
     fn classify(&self, class: &Class<A::Symbol>) -> Option<bool>;
@@ -161,6 +168,7 @@ impl<A: Alphabet> AnnotatedCongruence<A> {
                 info.expect("Every SCC must have a color")
             })
             .collect_pointed()
+            .into_moore()
     }
 
     /// Takes a reference to a right congruence and a function that classifies idempotents
@@ -171,19 +179,20 @@ impl<A: Alphabet> AnnotatedCongruence<A> {
         C: Clone,
         F: ClassifiesIdempotents<A>,
     {
-        Self(
-            rc.erase_edge_colors()
-                .map_state_colors(|c| {
-                    let cls = c.class();
-                    if !cls.is_empty() && rc.is_idempotent(cls) {
-                        let b = f.classify(cls);
-                        c.recolor(Annotation::new(true, b))
-                    } else {
-                        c.recolor(Annotation::new(false, None))
-                    }
-                })
-                .collect_pointed(),
-        )
+        let cong = rc
+            .erase_edge_colors()
+            .map_state_colors(|c| {
+                let cls = c.class();
+                if !cls.is_empty() && rc.is_idempotent(cls) {
+                    let b = f.classify(cls);
+                    Annotation::new(true, b)
+                } else {
+                    Annotation::new(false, None)
+                }
+            })
+            .collect_pointed::<DTS<_, Annotation, Void>>();
+        let rc = RightCongruence::from_ts(cong);
+        Self::new(rc)
     }
 }
 

--- a/automata/Cargo.toml
+++ b/automata/Cargo.toml
@@ -17,6 +17,7 @@ impl-tools = "0.10"
 paste = "1.0.14"
 biodivine-lib-bdd = { version = "0.5", optional = true }
 bit-set = "0.5.3"
+bimap = "0.6.3"
 fastrand = "2"
 # fork = { version = "0.1", optional = true }
 # show-image = { version = "0.13", optional = true }

--- a/automata/benches/ts.rs
+++ b/automata/benches/ts.rs
@@ -56,9 +56,9 @@ fn benchings(c: &mut Criterion) {
             black_box(
                 ref_dts
                     .map_edge_colors(|i| i * 2 - 7)
-                    .collect_ts()
+                    .collect_dts()
                     .map_state_colors(|j| j * 7 - 4)
-                    .collect_ts(),
+                    .collect_dts(),
             );
         })
     });
@@ -68,7 +68,7 @@ fn benchings(c: &mut Criterion) {
                 ref_dts
                     .map_edge_colors(|i| i + 2 - 7)
                     .map_state_colors(|j| j * 7 - 4)
-                    .collect_ts(),
+                    .collect_dts(),
             )
         })
     });

--- a/automata/src/automaton/dfa.rs
+++ b/automata/src/automaton/dfa.rs
@@ -103,7 +103,7 @@ pub trait DFALike: Deterministic<StateColor = bool> + Pointed
 
     /// Consumes and turns `self` into a [`DFA`]. Note, that this operation erases the edge colors.
     fn collect_dfa(self) -> DFA<Self::Alphabet> {
-        DFA::from(self.erase_edge_colors().collect_with_initial())
+        DFA::from(self.erase_edge_colors().trim_collect())
     }
 
     /// Uses a reference to `self` for creating a [`DFA`].

--- a/automata/src/automaton/dpa.rs
+++ b/automata/src/automaton/dpa.rs
@@ -12,7 +12,7 @@ use crate::{
     ts::{
         connected_components::Scc,
         operations::{MapEdgeColor, MapStateColor},
-        CollectDTS, IntoInitialBTS, Quotient, Shrinkable,
+        CollectDTS, Quotient, Shrinkable,
     },
     HasParity, Partition, Set,
 };
@@ -287,7 +287,7 @@ impl<D: DPALike> IntoDPA<D> {
     {
         let start = std::time::Instant::now();
 
-        let mut ts: Initialized<BTS<_, _, _, _>> = self.collect_pointed();
+        let mut ts: Initialized<HashTs<_, _, _, _>> = self.collect_pointed();
         let out = ts.clone();
 
         let mut recoloring = Vec::new();

--- a/automata/src/automaton/dpa.rs
+++ b/automata/src/automaton/dpa.rs
@@ -287,7 +287,7 @@ impl<D: DPALike> IntoDPA<D> {
     {
         let start = std::time::Instant::now();
 
-        let mut ts: Initialized<HashTs<_, D::StateColor, D::EdgeColor>> = self.collect_pointed();
+        let mut ts: Initialized<HashTs<_, D::StateColor, D::EdgeColor>> = self.collect_pointed().0;
         let out = ts.clone();
 
         let mut recoloring = Vec::new();

--- a/automata/src/automaton/dpa.rs
+++ b/automata/src/automaton/dpa.rs
@@ -287,7 +287,7 @@ impl<D: DPALike> IntoDPA<D> {
     {
         let start = std::time::Instant::now();
 
-        let mut ts: Initialized<HashTs<_, _, _, _>> = self.collect_pointed();
+        let mut ts: Initialized<HashTs<_, D::StateColor, D::EdgeColor>> = self.collect_pointed();
         let out = ts.clone();
 
         let mut recoloring = Vec::new();

--- a/automata/src/automaton/mealy.rs
+++ b/automata/src/automaton/mealy.rs
@@ -76,6 +76,8 @@ impl<A: Alphabet> MealyMachine<A> {
     }
 }
 
+impl<D: Deterministic> Deterministic for MealyMachine<D::Alphabet, D::EdgeColor, D> {}
+
 impl<Ts: TransitionSystem> TransitionSystem for MealyMachine<Ts::Alphabet, Ts::EdgeColor, Ts> {
     type StateIndex = Ts::StateIndex;
 
@@ -110,16 +112,6 @@ impl<Ts: TransitionSystem> TransitionSystem for MealyMachine<Ts::Alphabet, Ts::E
 
     fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
         self.ts().state_color(state.to_index(self)?)
-    }
-}
-
-impl<D: Deterministic> Deterministic for MealyMachine<D::Alphabet, D::EdgeColor, D> {
-    fn transition<Idx: Indexes<Self>>(
-        &self,
-        state: Idx,
-        symbol: SymbolOf<Self>,
-    ) -> Option<Self::EdgeRef<'_>> {
-        self.ts().transition(state.to_index(self)?, symbol)
     }
 }
 

--- a/automata/src/automaton/mealy.rs
+++ b/automata/src/automaton/mealy.rs
@@ -430,7 +430,7 @@ pub trait MealyLike: Congruence {
     }
 
     fn collect_mealy(self) -> AsMealyMachine<Self> {
-        let ts = self.erase_state_colors().collect_pointed();
+        let ts = self.erase_state_colors().collect_pointed().0;
         MealyMachine {
             ts,
             _q: PhantomData,

--- a/automata/src/automaton/mod.rs
+++ b/automata/src/automaton/mod.rs
@@ -16,8 +16,8 @@ use crate::{
         finite::{InfinityColors, ReachedColor},
         operations::{MapStateColor, MatchingProduct, Product, ProductIndex, ProductTransition},
         transition_system::IsEdge,
-        EdgeColor, HasMutableStates, HasStates, IndexType, Pointed, Quotient, Sproutable,
-        StateColor, SymbolOf, TransitionSystem, BTS,
+        EdgeColor, HashTs, IndexType, Pointed, Quotient, Sproutable, StateColor, SymbolOf,
+        TransitionSystem,
     },
     word::{OmegaWord, Reduced},
     Color, FiniteLength, InfiniteLength, Length,
@@ -295,7 +295,7 @@ mod tests {
             NoColor,
         },
         prelude::*,
-        ts::BTS,
+        ts::HashTs,
     };
 
     #[test]

--- a/automata/src/automaton/moore.rs
+++ b/automata/src/automaton/moore.rs
@@ -44,7 +44,7 @@ pub type AsMooreMachine<Ts> = MooreMachine<
 >;
 
 impl<A: Alphabet, Q: Color, C: Color> MooreMachine<A, Q, C> {
-    /// Creates a new MooreMachine on a [`BTS`].
+    /// Creates a new MooreMachine on a [`DTS`].
     pub fn new(
         alphabet: A,
         initial_state_output: Q,

--- a/automata/src/automaton/moore.rs
+++ b/automata/src/automaton/moore.rs
@@ -454,7 +454,7 @@ where
     /// Builds a moore machine from a reference to `self`. Note that this allocates a new
     /// transition system, which is a copy of the underlying one.
     fn collect_moore(&self) -> AsMooreMachine<Self> {
-        let ts = self.collect_pointed();
+        let ts = self.collect_pointed().0;
         MooreMachine {
             ts,
             _q: std::marker::PhantomData,

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -130,27 +130,3 @@ impl<Ts: TransitionSystem + Sproutable> Sproutable for Initialized<Ts> {
         self.ts_mut().extend_states(iter)
     }
 }
-impl<Ts: TransitionSystem + HasStates> HasStates for Initialized<Ts> {
-    type State<'this> = Ts::State<'this>
-        where
-            Self: 'this;
-
-    type StatesIter<'this> = Ts::StatesIter<'this>
-        where
-            Self: 'this;
-
-    fn state(&self, index: Self::StateIndex) -> Option<Self::State<'_>> {
-        self.ts().state(index)
-    }
-
-    fn states_iter(&self) -> Self::StatesIter<'_> {
-        self.ts().states_iter()
-    }
-}
-impl<Ts: TransitionSystem + HasMutableStates> HasMutableStates for Initialized<Ts> {
-    type StateMut<'this>  = Ts::StateMut<'this> where Self:'this;
-
-    fn state_mut(&mut self, index: Self::StateIndex) -> Option<Self::StateMut<'_>> {
-        self.ts_mut().state_mut(index)
-    }
-}

--- a/automata/src/congruence/mod.rs
+++ b/automata/src/congruence/mod.rs
@@ -90,7 +90,7 @@ impl<A: Alphabet, Q: Clone, C: Clone> RightCongruence<A, Q, C> {
         let mut cong = Self {
             ts: ts
                 .map_state_colors(|c| ColoredClass::new(Class::default(), c))
-                .collect_ts(),
+                .collect_dts(),
         };
         cong.recompute_labels();
         cong
@@ -164,7 +164,7 @@ impl<A: Alphabet, Q: Clone, C: Clone> RightCongruence<A, Q, C> {
     pub fn looping_words(&self, class: &Class<A::Symbol>) -> DFA<A> {
         self.map_state_colors(|c: ColoredClass<A::Symbol, Q>| c.class() == class)
             .erase_edge_colors()
-            .collect_ts()
+            .collect_dts()
             .with_initial(self.class_to_index(class).unwrap())
             .into_dfa()
     }

--- a/automata/src/congruence/mod.rs
+++ b/automata/src/congruence/mod.rs
@@ -34,15 +34,6 @@ impl<S: Symbol + Show, Q: Show> Show for ColoredClass<S, Q> {
     fn show(&self) -> String {
         format!("{} | {}", self.class.show(), self.color.show())
     }
-
-    fn show_collection<'a, I>(iter: I) -> String
-    where
-        Self: 'a,
-        I: IntoIterator<Item = &'a Self>,
-        I::IntoIter: DoubleEndedIterator,
-    {
-        todo!()
-    }
 }
 
 impl<S: Symbol + Show> Show for ColoredClass<S, Void> {

--- a/automata/src/lib.rs
+++ b/automata/src/lib.rs
@@ -41,8 +41,8 @@ pub mod prelude {
             predecessors::PredecessorIterable,
             transition_system::{EdgeReference, FullTransition, Indexes, IsEdge},
             Congruence, Deterministic, DeterministicEdgesFrom, EdgeColor, ExpressionOf, HasColor,
-            HasColorMut, HasMutableStates, HasStates, IndexType, Path, Sproutable, StateColor,
-            SymbolOf, TSBuilder, TransitionSystem, BTS, DTS, NTS,
+            HasColorMut, HashTs, IndexType, Path, Sproutable, StateColor, SymbolOf, TSBuilder,
+            TransitionSystem, DTS, NTS,
         },
         upw,
         word::{FiniteWord, LinearWord, OmegaWord, Periodic, Reduced, ReducedParseError},
@@ -168,6 +168,10 @@ impl Show for (&Void, &Void) {
 pub type Set<S> = fxhash::FxHashSet<S>;
 /// Type alias for maps, we use this to hide which type of `HashMap` we are actually using.
 pub type Map<K, V> = fxhash::FxHashMap<K, V>;
+
+/// Represents a bijective mapping between `L` and `R`, that is a mapping which associates
+/// each `L` with precisely one `R` and vice versa.
+pub type Bijection<L, R> = bimap::BiBTreeMap<L, R>;
 
 /// Helper trait which can be used to display states, transitions and such.
 pub trait Show {

--- a/automata/src/lib.rs
+++ b/automata/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! The crate defines some basic building blocks of TS which can easily be manipulated (see `Sproutable`), these are
 //! - [`ts::NTS`]/[`ts::DTS`] (the latter is just a thin wrapper around the former). These store edges in a vector, a state contains a pointer to the first edge in this collection and each edge contains pointers to the previous/next one.
-//! - [`ts::BTS`] which stores transitions in an efficient HashMap
+//! - [`ts::HashTs`] which stores transitions in an efficient HashMap
 //!
 //! Further traits that are of importance are
 //! - [`Pointed`] which picks one designated initial state, this is important for deterministic automata

--- a/automata/src/ts/dot.rs
+++ b/automata/src/ts/dot.rs
@@ -9,7 +9,8 @@ use crate::{
     automaton::{Initialized, IntoDPA},
     congruence::{ColoredClass, FORC},
     prelude::{
-        DPALike, IntoMealyMachine, IntoMooreMachine, MealyLike, MooreLike, Simple, Symbol, SymbolOf,
+        DPALike, EdgeColor, ExpressionOf, IntoMealyMachine, IntoMooreMachine, MealyLike, MooreLike,
+        Simple, StateColor, Symbol, SymbolOf,
     },
     ts::dot,
     Alphabet, Class, Color, Map, Pointed, RightCongruence, Show, TransitionSystem,
@@ -17,7 +18,7 @@ use crate::{
 
 use super::{
     transition_system::{Indexes, IsEdge},
-    Deterministic, EdgeColor, ExpressionOf, IndexType, StateColor, BTS,
+    Deterministic, HashTs, IndexType,
 };
 
 fn sanitize_dot_ident(name: &str) -> String {

--- a/automata/src/ts/index_ts.rs
+++ b/automata/src/ts/index_ts.rs
@@ -10,20 +10,20 @@ use crate::{
 };
 
 use super::{
-    EdgeColor, ExpressionOf, HasColor, HasColorMut, HasMutableStates, HasStates, IndexType,
-    Sproutable, StateColor, SymbolOf, TransitionSystem,
+    EdgeColor, ExpressionOf, HasColor, HasColorMut, IndexType, Sproutable, StateColor, SymbolOf,
+    TransitionSystem,
 };
 
 /// A state in a transition system. This stores the color of the state and the index of the
 /// first edge leaving the state.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub struct BTState<A: Alphabet, Q, C: Hash + Eq, Idx: IndexType> {
+pub struct HashTsState<A: Alphabet, Q, C: Hash + Eq, Idx: IndexType> {
     color: Q,
     edges: Map<A::Expression, (Idx, C)>,
     predecessors: Set<(Idx, A::Expression, C)>,
 }
 
-impl<A: Alphabet, Q, C: Clone + Hash + Eq, Idx: IndexType> BTState<A, Q, C, Idx> {
+impl<A: Alphabet, Q, C: Hash + Eq, Idx: IndexType> HashTsState<A, Q, C, Idx> {
     /// Creates a new state with the given color.
     pub fn new(color: Q) -> Self {
         Self {
@@ -73,8 +73,8 @@ impl<A: Alphabet, Q, C: Clone + Hash + Eq, Idx: IndexType> BTState<A, Q, C, Idx>
         self.edges.remove(on)
     }
 
-    pub fn recolor<P: Color>(self, color: P) -> BTState<A, P, C, Idx> {
-        BTState {
+    pub fn recolor<P: Color>(self, color: P) -> HashTsState<A, P, C, Idx> {
+        HashTsState {
             color,
             edges: self.edges,
             predecessors: self.predecessors,
@@ -88,7 +88,7 @@ impl<A: Alphabet, Q, C: Clone + Hash + Eq, Idx: IndexType> BTState<A, Q, C, Idx>
 }
 
 impl<A: Alphabet, Q: std::fmt::Display, C: Color, Idx: IndexType> std::fmt::Display
-    for BTState<A, Q, C, Idx>
+    for HashTsState<A, Q, C, Idx>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.color)
@@ -99,30 +99,30 @@ impl<A: Alphabet, Q: std::fmt::Display, C: Color, Idx: IndexType> std::fmt::Disp
 /// the states and edges in a vector, which allows for fast access and iteration. The states and edges
 /// are indexed by their position in the respective vector.
 #[derive(Clone, PartialEq, Eq)]
-pub struct BTS<A: Alphabet, Q, C: Hash + Eq, Idx: IndexType = usize> {
+pub struct HashTs<A: Alphabet, Q, C: Hash + Eq, Idx: IndexType = usize> {
     pub(crate) alphabet: A,
-    pub(crate) states: Map<Idx, BTState<A, Q, C, Idx>>,
+    pub(crate) states: Map<Idx, HashTsState<A, Q, C, Idx>>,
 }
 
-/// Type alias that takes a [`TransitionSystem`] and gives the type of a corresponding [`BTS`], i.e. one
+/// Type alias that takes a [`TransitionSystem`] and gives the type of a corresponding [`HashTs`], i.e. one
 /// with the same alphabet, edge and state colors.
-pub type IntoBTS<Ts> = BTS<
+pub type IntoHashTs<Ts> = HashTs<
     <Ts as TransitionSystem>::Alphabet,
     <Ts as TransitionSystem>::StateColor,
     <Ts as TransitionSystem>::EdgeColor,
 >;
 
-/// Type alias for a [`BTS`] with initial states. Given a [`TransitionSystem`] `Ts`, returns a [`BTS`] with the
+/// Type alias for a [`HashTs`] with initial states. Given a [`TransitionSystem`] `Ts`, returns a [`HashTs`] with the
 /// same alphabet, edge and state colors, wrapped in a [`Initialized`] type.
-pub type IntoInitialBTS<Ts> = Initialized<
-    BTS<
+pub type IntoInitialHashTs<Ts> = Initialized<
+    HashTs<
         <Ts as TransitionSystem>::Alphabet,
         <Ts as TransitionSystem>::StateColor,
         <Ts as TransitionSystem>::EdgeColor,
     >,
 >;
 
-impl<A, C, Q, Idx> std::fmt::Debug for BTS<A, Q, C, Idx>
+impl<A, C, Q, Idx> std::fmt::Debug for HashTs<A, Q, C, Idx>
 where
     A: Alphabet,
     C: Debug + Clone + Hash + Eq,
@@ -141,10 +141,10 @@ where
     }
 }
 
-pub type MealyTS<A, C, Idx = usize> = BTS<A, (), C, Idx>;
-pub type MooreTS<A, C, Idx = usize> = BTS<A, C, (), Idx>;
+pub type MealyTS<A, C, Idx = usize> = HashTs<A, (), C, Idx>;
+pub type MooreTS<A, C, Idx = usize> = HashTs<A, C, (), Idx>;
 
-impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, Idx> {
+impl<A: Alphabet, Idx: IndexType, C: Clone + Hash + Eq, Q: Clone> HashTs<A, Q, C, Idx> {
     /// Creates a new transition system with the given alphabet.
     pub fn new(alphabet: A) -> Self {
         Self {
@@ -153,7 +153,7 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
         }
     }
 
-    pub(crate) fn bts_remove_state(&mut self, idx: Idx) -> Option<Q> {
+    pub(crate) fn hashts_remove_state(&mut self, idx: Idx) -> Option<Q> {
         let state = self.states.remove(&idx)?;
         self.states.iter_mut().for_each(|(_, s)| {
             s.remove_incoming_edges_from(idx);
@@ -162,7 +162,7 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
         Some(state.color)
     }
 
-    pub(crate) fn bts_remove_edge(&mut self, from: Idx, on: &A::Expression) -> Option<(C, Idx)> {
+    pub(crate) fn hashts_remove_edge(&mut self, from: Idx, on: &A::Expression) -> Option<(C, Idx)> {
         let (to, color) = self.states.get_mut(&from)?.remove_edge(on)?;
         self.states
             .get_mut(&to)?
@@ -170,7 +170,7 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
         Some((color, to))
     }
 
-    pub(crate) fn bts_remove_transitions(
+    pub(crate) fn hashts_remove_transitions(
         &mut self,
         from: Idx,
         symbol: SymbolOf<Self>,
@@ -191,18 +191,18 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
             .collect()
     }
 
-    /// Creates a `BTS` from the given alphabet and states.
-    pub(crate) fn from_parts(alphabet: A, states: Map<Idx, BTState<A, Q, C, Idx>>) -> Self {
+    /// Creates a `HASHTS` from the given alphabet and states.
+    pub(crate) fn from_parts(alphabet: A, states: Map<Idx, HashTsState<A, Q, C, Idx>>) -> Self {
         Self { alphabet, states }
     }
 
-    /// Decomposes the `BTS` into its constituent parts.
+    /// Decomposes the `HASHTS` into its constituent parts.
     #[allow(clippy::type_complexity)]
-    pub(crate) fn into_parts(self) -> (A, Map<Idx, BTState<A, Q, C, Idx>>) {
+    pub(crate) fn into_parts(self) -> (A, Map<Idx, HashTsState<A, Q, C, Idx>>) {
         (self.alphabet, self.states)
     }
 
-    /// Creates an empty `BTS` ensuring the given capacity.
+    /// Creates an empty `HASHTS` ensuring the given capacity.
     pub fn with_capacity(alphabet: A, states: usize) -> Self
     where
         StateColor<Self>: Default,
@@ -214,7 +214,7 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
                 .map(|i| {
                     (
                         i.into(),
-                        BTState::new(<StateColor<Self> as Default>::default()),
+                        HashTsState::new(<StateColor<Self> as Default>::default()),
                     )
                 })
                 .collect(),
@@ -227,7 +227,7 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
     }
 
     /// Returns a reference to the underlying statemap.
-    pub fn raw_state_map(&self) -> &Map<Idx, BTState<A, Q, C, Idx>> {
+    pub fn raw_state_map(&self) -> &Map<Idx, HashTsState<A, Q, C, Idx>> {
         &self.states
     }
 
@@ -256,7 +256,7 @@ impl<A: Alphabet, Idx: IndexType, C: Hash + Eq + Clone, Q: Clone> BTS<A, Q, C, I
     }
 }
 
-impl<A: Alphabet, Idx: IndexType, Q: Clone + Hash + Eq, C: Clone + Hash + Eq> BTS<A, Q, C, Idx> {
+impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone + Hash + Eq> HashTs<A, Q, C, Idx> {
     /// Returns an iterator over the [`EdgeIndex`]es of the edges leaving the given state.
     pub(crate) fn index_ts_edges_from(
         &self,
@@ -271,14 +271,14 @@ impl<A: Alphabet, Idx: IndexType, Q: Clone + Hash + Eq, C: Clone + Hash + Eq> BT
     }
 }
 
-impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq> Sproutable for BTS<A, Q, C, usize> {
+impl<A: Alphabet, Q: Clone, C: Clone + Hash + Eq> Sproutable for HashTs<A, Q, C, usize> {
     type ExtendStateIndexIter = std::ops::Range<Self::StateIndex>;
     fn extend_states<I: IntoIterator<Item = StateColor<Self>>>(
         &mut self,
         iter: I,
     ) -> Self::ExtendStateIndexIter {
         let n = self.states.len();
-        let it = (n..).zip(iter.into_iter().map(|c| BTState::new(c)));
+        let it = (n..).zip(iter.into_iter().map(|c| HashTsState::new(c)));
         self.states.extend(it);
         n..self.states.len()
     }
@@ -287,7 +287,7 @@ impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq> Sproutable for BTS
     /// the new state.
     fn add_state<X: Into<StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {
         let id = self.states.len();
-        let state = BTState::new(color.into());
+        let state = HashTsState::new(color.into());
         self.states.insert(id, state);
         id
     }

--- a/automata/src/ts/index_ts.rs
+++ b/automata/src/ts/index_ts.rs
@@ -99,7 +99,8 @@ impl<A: Alphabet, Q: std::fmt::Display, C: Color, Idx: IndexType> std::fmt::Disp
 /// the states and edges in a vector, which allows for fast access and iteration. The states and edges
 /// are indexed by their position in the respective vector.
 #[derive(Clone, PartialEq, Eq)]
-pub struct HashTs<A: Alphabet, Q, C: Hash + Eq, Idx: IndexType = usize> {
+pub struct HashTs<A: Alphabet, Q = crate::Void, C: Hash + Eq = crate::Void, Idx: IndexType = usize>
+{
     pub(crate) alphabet: A,
     pub(crate) states: Map<Idx, HashTsState<A, Q, C, Idx>>,
 }

--- a/automata/src/ts/mod.rs
+++ b/automata/src/ts/mod.rs
@@ -13,7 +13,7 @@ pub mod operations;
 use crate::{Class, Color, Map, RightCongruence, Show, Void};
 
 mod index_ts;
-pub use index_ts::{IntoBTS, IntoInitialBTS, BTS};
+pub use index_ts::{HashTs, IntoHashTs};
 
 /// Contains implementations and definitions for dealing with paths through a transition system.
 pub mod path;
@@ -170,46 +170,6 @@ impl<'a, Q> StateReference<'a, Q> {
 pub type StateColor<X> = <X as TransitionSystem>::StateColor;
 /// Type alias for extracting the edge color in a [`TransitionSystem`].
 pub type EdgeColor<X> = <X as TransitionSystem>::EdgeColor;
-
-/// Abstracts possessing a set of states. Note, that implementors of this trait must
-/// be able to iterate over the set of states.
-#[autoimpl(for<T: trait + ?Sized> &T, &mut T)]
-pub trait HasStates: TransitionSystem + Sized {
-    /// The type of the states.
-    type State<'this>: HasColor<Color = StateColor<Self>>
-    where
-        Self: 'this;
-
-    /// The type of the iterator over the states.
-    type StatesIter<'this>: Iterator<Item = (&'this Self::StateIndex, Self::State<'this>)>
-    where
-        Self: 'this;
-
-    /// Returns a reference to the state with the given index, if it exists and `None` otherwise.
-    fn state(&self, index: Self::StateIndex) -> Option<Self::State<'_>>;
-
-    /// Returns an iterator over the states of the implementor.
-    fn states_iter(&self) -> Self::StatesIter<'_>;
-
-    /// Returns the number of states.
-    fn hs_size(&self) -> usize {
-        self.states_iter().count()
-    }
-}
-
-/// Abstracts possessing a set of states, which can be mutated. Note, that implementors of this
-/// trait must be able to iterate over the set of states.
-#[autoimpl(for<T: trait + ?Sized> &mut T)]
-
-pub trait HasMutableStates: HasStates {
-    /// The type of the mutable iterator over the states.
-    type StateMut<'this>: HasColorMut<Color = StateColor<Self>>
-    where
-        Self: 'this;
-
-    /// Returns an iterator over mutable references to the states of the implementor.
-    fn state_mut(&mut self, index: Self::StateIndex) -> Option<Self::StateMut<'_>>;
-}
 
 /// Implementors of this trait have a distinguished (initial) state.
 #[autoimpl(for<T: trait> &T, &mut T)]

--- a/automata/src/ts/operations/map.rs
+++ b/automata/src/ts/operations/map.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::prelude::*;
+use crate::{prelude::*, ts::nts::NTSPartsFor};
 
 /// A transition system that maps the edge colors of a given transition system to a new type.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -262,6 +262,10 @@ impl<Ts, F> MapEdgeColor<Ts, F> {
     pub fn ts(&self) -> &Ts {
         &self.ts
     }
+
+    pub fn into_parts(self) -> (Ts, F) {
+        (self.ts, self.f)
+    }
 }
 
 impl<D: Clone, Ts: TransitionSystem + Pointed, F: Fn(Ts::EdgeColor) -> D> Pointed
@@ -431,6 +435,10 @@ impl<Ts, F> MapStateColor<Ts, F> {
 
     pub fn ts(&self) -> &Ts {
         &self.ts
+    }
+
+    pub fn into_parts(self) -> (Ts, F) {
+        (self.ts, self.f)
     }
 
     pub fn f(&self) -> &F {

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -209,7 +209,7 @@ impl<Ts: TransitionSystem> SubsetConstruction<Ts> {
 mod tests {
     use crate::{
         prelude::Initialized,
-        ts::{Deterministic, BTS, NTS},
+        ts::{Deterministic, HashTs, NTS},
         TransitionSystem,
     };
 

--- a/automata/src/ts/predecessors.rs
+++ b/automata/src/ts/predecessors.rs
@@ -10,7 +10,7 @@ use super::{
         Reversed, StateIndexFilter,
     },
     transition_system::{EdgeReference, IsEdge},
-    EdgeColor, ExpressionOf, IndexType, SymbolOf, BTS,
+    EdgeColor, ExpressionOf, HashTs, IndexType, SymbolOf,
 };
 
 /// Implementors of this trait are [`TransitionSystem`]s which allow iterating over the predecessors of a state.
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> PredecessorIterable for BTS<A, Q, C, Idx> {
+impl<A: Alphabet, Idx: IndexType, Q: Color, C: Color> PredecessorIterable for HashTs<A, Q, C, Idx> {
     type PreEdgeRef<'this> = EdgeReference<'this, A::Expression, Idx, C> where Self: 'this;
     type EdgesToIter<'this> = BTSPredecessors<'this, A, C, Idx>
     where

--- a/automata/src/ts/shrinkable.rs
+++ b/automata/src/ts/shrinkable.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use crate::{automaton::Initialized, Alphabet, Color, Set, TransitionSystem};
 
-use super::{transition_system::Indexes, ExpressionOf, IndexType, SymbolOf, BTS, DTS, NTS};
+use super::{transition_system::Indexes, ExpressionOf, HashTs, IndexType, SymbolOf, DTS, NTS};
 
 /// Encapsulates the ability to remove states, edges, and transitions from a transition system.
 pub trait Shrinkable: TransitionSystem {
@@ -34,10 +34,10 @@ pub trait Shrinkable: TransitionSystem {
 }
 
 impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq, Index: IndexType> Shrinkable
-    for BTS<A, Q, C, Index>
+    for HashTs<A, Q, C, Index>
 {
     fn remove_state<Idx: Indexes<Self>>(&mut self, state: Idx) -> Option<Self::StateColor> {
-        self.bts_remove_state(state.to_index(self)?)
+        self.hashts_remove_state(state.to_index(self)?)
     }
 
     fn remove_edge<Idx: Indexes<Self>>(
@@ -45,7 +45,7 @@ impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq, Index: IndexType> 
         source: Idx,
         expression: &ExpressionOf<Self>,
     ) -> Option<(Self::EdgeColor, Self::StateIndex)> {
-        self.bts_remove_edge(source.to_index(self)?, expression)
+        self.hashts_remove_edge(source.to_index(self)?, expression)
     }
 
     fn remove_transitions<Idx: Indexes<Self>>(
@@ -53,7 +53,7 @@ impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq, Index: IndexType> 
         source: Idx,
         symbol: &SymbolOf<Self>,
     ) -> Option<Set<(ExpressionOf<Self>, Self::EdgeColor, Self::StateIndex)>> {
-        Some(self.bts_remove_transitions(source.to_index(self)?, *symbol))
+        Some(self.hashts_remove_transitions(source.to_index(self)?, *symbol))
     }
 }
 

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -66,15 +66,15 @@ pub trait Sproutable: TransitionSystem {
     ///
     /// # Example
     /// ```
-    /// use crate::prelude::*;
+    /// use automata::prelude::*;
     ///
     /// let source = TSBuilder::default()
     ///     .with_transitions([(0, 'a', 0, 0), (0, 'b', 0, 0)])
     ///     .with_colors([0])
     ///     .deterministic();
     ///
-    /// let without_edge_colors: DTS<Simple, usize, Void> = DTS::collect_from(&source);
-    /// let without_state_colors: DTS<Simple, Void, usize> = DTS::collect_from(&source);
+    /// let (without_edge_colors, _): DTS<Simple, usize, Void> = DTS::collect_from(&source);
+    /// let (without_state_colors, _): DTS<Simple, Void, usize> = DTS::collect_from(&source);
     /// ```
     fn collect_from<Ts>(ts: Ts) -> (Self, Bijection<Ts::StateIndex, Self::StateIndex>)
     where

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -73,8 +73,8 @@ pub trait Sproutable: TransitionSystem {
     ///     .with_colors([0])
     ///     .deterministic();
     ///
-    /// let (without_edge_colors, _): DTS<Simple, usize, Void> = DTS::collect_from(&source);
-    /// let (without_state_colors, _): DTS<Simple, Void, usize> = DTS::collect_from(&source);
+    /// let (without_edge_colors, _): (DTS<Simple, usize, Void>, _) = DTS::collect_from(&source);
+    /// let (without_state_colors, _): (DTS<Simple, Void, usize>, _) = DTS::collect_from(&source);
     /// ```
     fn collect_from<Ts>(ts: Ts) -> (Self, Bijection<Ts::StateIndex, Self::StateIndex>)
     where

--- a/automata/src/ts/transition_system.rs
+++ b/automata/src/ts/transition_system.rs
@@ -13,7 +13,7 @@ use super::{
     connected_components::{
         tarjan_scc_iterative, tarjan_scc_recursive, SccDecomposition, TarjanDAG,
     },
-    index_ts::BTState,
+    index_ts::HashTsState,
     nts::{NTEdge, NTSEdgesFromIter},
     operations::{
         ColorRestricted, MapEdgeColor, MapStateColor, MappedEdgesFromIter, MappedTransition,
@@ -29,7 +29,7 @@ use super::{
 use super::{
     finite::{ReachedColor, ReachedState},
     path::Lasso,
-    CanInduce, EdgeColor, IndexType, Induced, Path, StateColor, BTS,
+    CanInduce, EdgeColor, HashTs, IndexType, Induced, Path, StateColor,
 };
 
 use impl_tools::autoimpl;
@@ -982,15 +982,15 @@ impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for RightCongruence<A, Q,
         Some(self.initial())
     }
 }
-impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Hash + Eq + Clone> TransitionSystem
-    for BTS<A, Q, C, Idx>
+impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone + Hash + Eq> TransitionSystem
+    for HashTs<A, Q, C, Idx>
 {
     type StateColor = Q;
     type EdgeColor = C;
     type StateIndex = Idx;
     type EdgeRef<'this> = EdgeReference<'this, A::Expression, Idx, C> where Self: 'this;
     type EdgesFromIter<'this> = BTSEdgesFrom<'this, A::Expression, Idx, C> where Self: 'this;
-    type StateIndices<'this> = std::iter::Cloned<std::collections::hash_map::Keys<'this, Idx, super::index_ts::BTState<A, Q, C, Idx>>> where Self: 'this;
+    type StateIndices<'this> = std::iter::Cloned<std::collections::hash_map::Keys<'this, Idx, super::index_ts::HashTsState<A, Q, C, Idx>>> where Self: 'this;
 
     type Alphabet = A;
 


### PR DESCRIPTION
This PR implements the rework of `collect_...` methods on the `Deterministic` trait. We now use a unified approach via the `Sproutable::collect_from` method, which allows 'downcasting' of edge and state colors. The price we pay for this is that sometimes the specific transition system into which we want to collect needs to be specified.

Various collect methods now additionally return a bijective mapping between old and new state indices.