### PR TITLE
Use `Indexes` in methods on `Sproutable`

### DIFF
--- a/automata/src/automaton/mod.rs
+++ b/automata/src/automaton/mod.rs
@@ -163,10 +163,24 @@ macro_rules! impl_automaton_type {
                 color: EdgeColor<Self>,
             ) -> Option<(Self::StateIndex, Self::EdgeColor)>
             where
-                X: Into<Self::StateIndex>,
-                Y: Into<Self::StateIndex>,
+                X: Indexes<Self>,
+                Y: Indexes<Self>,
             {
+                let from = from.to_index(self)?;
+                let to = to.to_index(self)?;
                 self.ts_mut().add_edge(from, on, to, color)
+            }
+            fn remove_edges<X>(
+                &mut self,
+                from: X,
+                on: <Self::Alphabet as Alphabet>::Expression,
+            ) -> bool
+            where
+                X: Indexes<Self>
+            {
+                from.to_index(self)
+                    .map(|idx| self.ts_mut().remove_edges(idx, on))
+                    .unwrap_or(false)
             }
             fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
                 Self {
@@ -176,13 +190,6 @@ macro_rules! impl_automaton_type {
             }
             fn add_state<X: Into<StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {
                 self.ts_mut().add_state(color)
-            }
-            fn remove_edges(
-                &mut self,
-                from: Self::StateIndex,
-                on: <Self::Alphabet as Alphabet>::Expression,
-            ) -> bool {
-                self.ts_mut().remove_edges(from, on)
             }
         }
         impl<Ts: TransitionSystem> TransitionSystem

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -100,18 +100,20 @@ impl<Ts: TransitionSystem + Sproutable> Sproutable for Initialized<Ts> {
         color: EdgeColor<Self>,
     ) -> Option<(Self::StateIndex, Self::EdgeColor)>
     where
-        X: Into<Self::StateIndex>,
-        Y: Into<Self::StateIndex>,
+        X: Indexes<Self>,
+        Y: Indexes<Self>,
     {
+        let from = from.to_index(self)?;
+        let to = to.to_index(self)?;
         self.ts_mut().add_edge(from, on, to, color)
     }
-
-    fn remove_edges(
-        &mut self,
-        from: Self::StateIndex,
-        on: <Self::Alphabet as Alphabet>::Expression,
-    ) -> bool {
-        self.ts_mut().remove_edges(from, on)
+    fn remove_edges<X>(&mut self, from: X, on: <Self::Alphabet as Alphabet>::Expression) -> bool
+    where
+        X: Indexes<Self>,
+    {
+        from.to_index(self)
+            .map(|idx| self.ts_mut().remove_edges(idx, on))
+            .unwrap_or(false)
     }
 
     fn add_state<X: Into<StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {

--- a/automata/src/ts/dts.rs
+++ b/automata/src/ts/dts.rs
@@ -107,22 +107,19 @@ impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for DTS<A, Q, C> {
         color: EdgeColor<Self>,
     ) -> Option<(Self::StateIndex, Self::EdgeColor)>
     where
-        X: Into<Self::StateIndex>,
-        Y: Into<Self::StateIndex>,
+        X: Indexes<Self>,
+        Y: Indexes<Self>,
     {
-        let source = from.into();
-        let target = to.into();
-        // on.for_each(|sym| assert!(self.transition(source, sym).is_none()));
-
-        self.0.add_edge(source, on, target, color)
+        self.0
+            .add_edge(from.to_index(self)?, on, to.to_index(self)?, color)
     }
-
-    fn remove_edges(
-        &mut self,
-        from: Self::StateIndex,
-        on: <Self::Alphabet as Alphabet>::Expression,
-    ) -> bool {
-        self.0.remove_edges(from, on)
+    fn remove_edges<X>(&mut self, from: X, on: <Self::Alphabet as Alphabet>::Expression) -> bool
+    where
+        X: Indexes<Self>,
+    {
+        from.to_index(self)
+            .map(|idx| self.0.remove_edges(idx, on))
+            .unwrap_or(false)
     }
 }
 

--- a/automata/src/ts/nts.rs
+++ b/automata/src/ts/nts.rs
@@ -156,11 +156,11 @@ impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for NTS<A, Q, C> {
         color: EdgeColor<Self>,
     ) -> Option<(Self::StateIndex, Self::EdgeColor)>
     where
-        X: Into<Self::StateIndex>,
-        Y: Into<Self::StateIndex>,
+        X: Indexes<Self>,
+        Y: Indexes<Self>,
     {
-        let source = from.into();
-        let target = to.into();
+        let source = from.to_index(self)?;
+        let target = to.to_index(self)?;
 
         let mut edge = NTEdge::new(source, on, color, target);
         let edge_id = self.edges.len();
@@ -178,11 +178,14 @@ impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for NTS<A, Q, C> {
         None
     }
 
-    fn remove_edges(
+    fn remove_edges<X: Indexes<Self>>(
         &mut self,
-        from: Self::StateIndex,
+        from: X,
         on: <Self::Alphabet as Alphabet>::Expression,
     ) -> bool {
+        let Some(from) = from.to_index(self) else {
+            return false;
+        };
         let mut b = false;
         while let Some(pos) = self.edge_position(from, &on) {
             self.remove_edge(from, pos);

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -3,7 +3,10 @@ use itertools::Itertools;
 
 use crate::{prelude::Simple, Alphabet, Bijection, Pointed, TransitionSystem};
 
-use super::{transition_system::IsEdge, EdgeColor, StateColor};
+use super::{
+    transition_system::{Indexes, IsEdge},
+    EdgeColor, StateColor,
+};
 
 /// Marker trait for [`Alphabet`]s that can be indexed, i.e. where we can associate each
 /// [`Alphabet::Symbol`] and [`Alphabet::Expression`] with a unique index (a `usize`).
@@ -184,14 +187,14 @@ pub trait Sproutable: TransitionSystem {
         color: EdgeColor<Self>,
     ) -> Option<(Self::StateIndex, Self::EdgeColor)>
     where
-        X: Into<Self::StateIndex>,
-        Y: Into<Self::StateIndex>;
+        X: Indexes<Self>,
+        Y: Indexes<Self>;
 
     /// Removes the transition from the state `from` to the state `to` on the given expression.
     /// Returns `true` if the transition existed and was removed, `false` otherwise.
-    fn remove_edges(
+    fn remove_edges<X: Indexes<Self>>(
         &mut self,
-        from: Self::StateIndex,
+        from: X,
         on: <Self::Alphabet as Alphabet>::Expression,
     ) -> bool;
 


### PR DESCRIPTION
The `Indexes` trait is meant as a way for allowing more different types to be used as identifier of a state in a transition system.

Some methods on the `Sproutable` trait did not use the full generality offered by the `Indexes` trait. This has now been rectified.