### PR TITLE
Make methods take `Indexes` consistently

### DIFF
--- a/automata-learning/src/passive/precise.rs
+++ b/automata-learning/src/passive/precise.rs
@@ -7,6 +7,7 @@ use automata::{
     ts::{
         dot::{DotStateAttribute, DotTransitionAttribute},
         reachable::ReachableStateIndices,
+        transition_system::Indexes,
         Deterministic, Dottable, EdgeColor, ExpressionOf, IndexType, Sproutable, StateColor,
     },
     Alphabet, Map, Pointed, RightCongruence, Show, TransitionSystem, Void,
@@ -302,7 +303,8 @@ impl<A: Alphabet, const N: usize> TransitionSystem for PreciseDPA<A, N> {
         self.reachable_state_indices()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         Some(Void)
     }
 

--- a/automata/src/automaton/acceptor.rs
+++ b/automata/src/automaton/acceptor.rs
@@ -4,7 +4,9 @@ use crate::{
     Alphabet, Pointed, TransitionSystem,
 };
 
-use super::{Congruence, Deterministic, FiniteRun, FiniteWord, OmegaRun, PredecessorIterable};
+use super::{
+    Congruence, Deterministic, FiniteRun, FiniteWord, Indexes, OmegaRun, PredecessorIterable,
+};
 
 /// An automaton consists of a transition system and an acceptance condition.
 /// There are many different types of automata, which can be instantiated from
@@ -125,8 +127,8 @@ impl<D: PredecessorIterable, A, const OMEGA: bool> PredecessorIterable for Autom
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
-        self.ts.predecessors(state)
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
+        self.ts.predecessors(state.to_index(self)?)
     }
 }
 
@@ -153,11 +155,18 @@ impl<D: Sproutable, A: Default, const OMEGA: bool> Sproutable for Automaton<D, A
     ) -> Self::ExtendStateIndexIter {
         self.ts.extend_states(iter)
     }
-
-    fn set_state_color<X: Into<StateColor<Self>>>(&mut self, index: Self::StateIndex, color: X) {
-        self.ts.set_state_color(index, color)
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
+        &mut self,
+        index: Idx,
+        color: X,
+    ) {
+        self.ts.set_state_color(
+            index
+                .to_index(self)
+                .expect("cannot set color of state that does not exist"),
+            color,
+        )
     }
-
     fn add_edge<X, Y, CI>(
         &mut self,
         from: X,
@@ -220,8 +229,8 @@ impl<D: TransitionSystem, A, const OMEGA: bool> TransitionSystem for Automaton<D
         self.ts.edges_from(state.to_index(self)?)
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        self.ts.state_color(state)
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        self.ts.state_color(state.to_index(self)?)
     }
 }
 

--- a/automata/src/automaton/omega.rs
+++ b/automata/src/automaton/omega.rs
@@ -189,8 +189,8 @@ impl<A: Alphabet> TransitionSystem for OmegaAutomaton<A> {
         self.ts.edges_from(state.to_index(self)?)
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        self.ts.state_color(state)
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        self.ts.state_color(state.to_index(self)?)
     }
 }
 
@@ -227,8 +227,8 @@ impl<A: Alphabet> TransitionSystem for DeterministicOmegaAutomaton<A> {
         self.ts.edges_from(state.to_index(self)?)
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        self.ts.state_color(state)
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        self.ts.state_color(state.to_index(self)?)
     }
 }
 
@@ -241,8 +241,8 @@ impl<A: Alphabet> PredecessorIterable for OmegaAutomaton<A> {
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
-        self.ts.predecessors(state)
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
+        self.ts.predecessors(state.to_index(self)?)
     }
 }
 
@@ -255,8 +255,8 @@ impl<A: Alphabet> PredecessorIterable for DeterministicOmegaAutomaton<A> {
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
-        self.ts.predecessors(state)
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
+        self.ts.predecessors(state.to_index(self)?)
     }
 }
 

--- a/automata/src/automaton/with_initial.rs
+++ b/automata/src/automaton/with_initial.rs
@@ -120,7 +120,15 @@ impl<Ts: TransitionSystem + Sproutable> Sproutable for Initialized<Ts> {
         self.ts_mut().add_state(color)
     }
 
-    fn set_state_color<X: Into<StateColor<Self>>>(&mut self, index: Self::StateIndex, color: X) {
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
+        &mut self,
+        index: Idx,
+        color: X,
+    ) {
+        let Some(index) = index.to_index(self) else {
+            tracing::error!("cannot set color of state that does not exist");
+            return;
+        };
         self.ts_mut().set_state_color(index, color)
     }
 

--- a/automata/src/congruence/cayley.rs
+++ b/automata/src/congruence/cayley.rs
@@ -71,8 +71,10 @@ where
         Some(DeterministicEdgesFrom::new(self, state.to_index(self)?))
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        self.monoid().get_profile(state).map(|p| p.0.clone())
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        self.monoid()
+            .get_profile(state.to_index(self)?)
+            .map(|p| p.0.clone())
     }
 }
 
@@ -211,8 +213,10 @@ where
         Some(DeterministicEdgesFrom::new(self, state.to_index(self)?))
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        self.monoid().get_profile(state).map(|p| p.0.clone())
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        self.monoid()
+            .get_profile(state.to_index(self)?)
+            .map(|p| p.0.clone())
     }
 }
 

--- a/automata/src/congruence/mod.rs
+++ b/automata/src/congruence/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     alphabet::{CharAlphabet, Symbol},
     automaton::IntoDFA,
     prelude::{DFALike, IsEdge},
-    ts::{transition_system::Indexes, Deterministic, EdgeColor, Sproutable, DTS},
+    ts::{transition_system::Indexes, Deterministic, EdgeColor, Sproutable, StateColor, DTS},
     word::FiniteWord,
     Alphabet, Color, FiniteLength, HasLength, Map, Pointed, Show, TransitionSystem, Void, DFA,
 };
@@ -173,11 +173,15 @@ impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for RightCongruence<A, Q, C> {
         self.ts.add_state(color.into())
     }
 
-    fn set_state_color<X: Into<crate::ts::StateColor<Self>>>(
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
         &mut self,
-        index: Self::StateIndex,
+        index: Idx,
         color: X,
     ) {
+        let Some(index) = index.to_index(self) else {
+            tracing::error!("cannot set color of state that does not exist");
+            return;
+        };
         self.ts.set_state_color(index, color.into())
     }
 

--- a/automata/src/ts/deterministic.rs
+++ b/automata/src/ts/deterministic.rs
@@ -123,19 +123,20 @@ pub trait Deterministic: TransitionSystem {
     /// assert_eq!(ts.successor_index(0, 'b'), Some(1));
     /// assert_eq!(ts.successor_index(0, 'c'), None);
     /// ```
-    fn successor_index(
+    fn successor_index<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         symbol: SymbolOf<Self>,
     ) -> Option<Self::StateIndex> {
-        self.transition(state, symbol).map(|t| t.target())
+        self.transition(state.to_index(self)?, symbol)
+            .map(|t| t.target())
     }
 
     /// Returns the color of an edge starting in the given `state` and labeled with the given
     /// `expression`, if it exists. Otherwise, `None` is returned.
-    fn edge_color(
+    fn edge_color<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         expression: &ExpressionOf<Self>,
     ) -> Option<EdgeColor<Self>> {
         let mut symbols = expression.symbols();
@@ -145,7 +146,7 @@ pub trait Deterministic: TransitionSystem {
             None,
             "There are multiple symbols for this expression"
         );
-        Some(self.transition(state, sym)?.color().clone())
+        Some(self.transition(state.to_index(self)?, sym)?.color().clone())
     }
 
     /// Attempts to find the minimal representative of the indexed `state`, which the the length-lexicographically
@@ -736,26 +737,25 @@ impl<A: Alphabet, Q: Clone, C: Clone> Deterministic for RightCongruence<A, Q, C>
     ) -> Option<Self::EdgeRef<'_>> {
         self.ts().transition(state.to_index(self)?, symbol)
     }
-
-    fn edge_color(
+    fn edge_color<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         expression: &ExpressionOf<Self>,
-    ) -> Option<crate::ts::EdgeColor<Self>> {
-        self.ts().edge_color(state, expression)
+    ) -> Option<EdgeColor<Self>> {
+        self.ts().edge_color(state.to_index(self)?, expression)
     }
 }
 
-impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Hash + Eq + Clone> Deterministic
-    for HashTs<A, Q, C, Idx>
+impl<A: Alphabet, IdType: IndexType, Q: Clone, C: Hash + Eq + Clone> Deterministic
+    for HashTs<A, Q, C, IdType>
 {
-    fn edge_color(
+    fn edge_color<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         expression: &ExpressionOf<Self>,
     ) -> Option<EdgeColor<Self>> {
         self.raw_state_map()
-            .get(&state)
+            .get(&state.to_index(self)?)
             .and_then(|o| o.edge_map().get(expression).map(|(_, c)| c.clone()))
     }
 
@@ -779,12 +779,12 @@ where
     L::StateColor: Clone,
     R::StateColor: Clone,
 {
-    fn edge_color(
+    fn edge_color<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         expression: &ExpressionOf<Self>,
     ) -> Option<EdgeColor<Self>> {
-        let ProductIndex(l, r) = state;
+        let ProductIndex(l, r) = state.to_index(self)?;
         let left = self.0.edge_color(l, expression)?;
         let right = self.1.edge_color(r, expression)?;
         Some((left, right))
@@ -821,14 +821,6 @@ where
         DTS::from_parts(alphabet, states, edges)
     }
 
-    fn edge_color(
-        &self,
-        state: Self::StateIndex,
-        expression: &ExpressionOf<Self>,
-    ) -> Option<EdgeColor<Self>> {
-        self.ts().edge_color(state, expression)
-    }
-
     fn transition<Idx: Indexes<Self>>(
         &self,
         state: Idx,
@@ -851,13 +843,13 @@ where
         DTS::from_parts(alphabet, states, edges)
     }
 
-    fn edge_color(
+    fn edge_color<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         expression: &ExpressionOf<Self>,
     ) -> Option<EdgeColor<Self>> {
         self.ts()
-            .edge_color(state, expression)
+            .edge_color(state.to_index(self)?, expression)
             .map(|c| (self.f())(c))
     }
 
@@ -877,16 +869,16 @@ impl<Ts: Deterministic, F> Deterministic for RestrictByStateIndex<Ts, F>
 where
     F: StateIndexFilter<Ts::StateIndex>,
 {
-    fn edge_color(
+    fn edge_color<Idx: Indexes<Self>>(
         &self,
-        state: Self::StateIndex,
+        state: Idx,
         expression: &ExpressionOf<Self>,
-    ) -> Option<crate::ts::EdgeColor<Self>> {
+    ) -> Option<EdgeColor<Self>> {
+        let state = state.to_index(self)?;
         self.ts()
             .edge_color(state, expression)
             .filter(|_| (self.filter()).is_unmasked(state))
     }
-
     fn transition<Idx: Indexes<Self>>(
         &self,
         state: Idx,
@@ -905,14 +897,6 @@ where
     D: Clone,
     F: Fn(Ts::StateIndex, &ExpressionOf<Ts>, Ts::EdgeColor, Ts::StateIndex) -> D,
 {
-    fn edge_color(
-        &self,
-        state: Self::StateIndex,
-        expression: &ExpressionOf<Self>,
-    ) -> Option<crate::ts::EdgeColor<Self>> {
-        todo!()
-    }
-
     fn transition<Idx: crate::ts::transition_system::Indexes<Self>>(
         &self,
         state: Idx,

--- a/automata/src/ts/dts.rs
+++ b/automata/src/ts/dts.rs
@@ -57,9 +57,8 @@ impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for DTS<A, Q, C> {
     fn edges_from<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesFromIter<'_>> {
         self.0.edges_from(state.to_index(self)?)
     }
-
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
-        self.0.state_color(state)
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        self.0.state_color(state.to_index(self)?)
     }
 }
 
@@ -72,8 +71,8 @@ impl<A: Alphabet, Q: Clone, C: Clone> PredecessorIterable for DTS<A, Q, C> {
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
-        self.0.predecessors(state)
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
+        self.0.predecessors(state.to_index(self)?)
     }
 }
 
@@ -95,7 +94,15 @@ impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for DTS<A, Q, C> {
         self.0.extend_states(iter)
     }
 
-    fn set_state_color<X: Into<StateColor<Self>>>(&mut self, index: Self::StateIndex, color: X) {
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
+        &mut self,
+        index: Idx,
+        color: X,
+    ) {
+        let Some(index) = index.to_index(self) else {
+            tracing::error!("cannot set color of state that does not exist");
+            return;
+        };
         self.0.set_state_color(index, color)
     }
 

--- a/automata/src/ts/index_ts.rs
+++ b/automata/src/ts/index_ts.rs
@@ -327,7 +327,15 @@ impl<A: Alphabet, Q: Clone, C: Clone + Hash + Eq> Sproutable for HashTs<A, Q, C,
             .and_then(|o| o.add_edge(on, target, color))
     }
 
-    fn set_state_color<X: Into<StateColor<Self>>>(&mut self, index: Self::StateIndex, color: X) {
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
+        &mut self,
+        index: Idx,
+        color: X,
+    ) {
+        let Some(index) = index.to_index(self) else {
+            tracing::error!("cannot set color of state that does not exist");
+            return;
+        };
         self.states
             .get_mut(&index)
             .expect("State must exist")

--- a/automata/src/ts/nts.rs
+++ b/automata/src/ts/nts.rs
@@ -138,7 +138,15 @@ impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for NTS<A, Q, C> {
         i..self.states.len()
     }
 
-    fn set_state_color<X: Into<StateColor<Self>>>(&mut self, index: Self::StateIndex, color: X) {
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
+        &mut self,
+        index: Idx,
+        color: X,
+    ) {
+        let Some(index) = index.to_index(self) else {
+            tracing::error!("cannot set color of state that does not exist");
+            return;
+        };
         if index >= self.states.len() {
             panic!(
                 "Index {index} is out of bounds, there are only {} states",
@@ -428,7 +436,8 @@ impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for NTS<A, Q, C> {
         ))
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         if state >= self.states.len() {
             panic!(
                 "index {state} is out of bounds, there are only {} states",
@@ -475,7 +484,8 @@ impl<A: Alphabet, Q: Clone, C: Clone> PredecessorIterable for NTS<A, Q, C> {
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
+        let state = state.to_index(self)?;
         if state < self.states.len() {
             Some(NTSEdgesTo::new(self, state))
         } else {

--- a/automata/src/ts/operations/map.rs
+++ b/automata/src/ts/operations/map.rs
@@ -88,7 +88,7 @@ where
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
         todo!()
     }
 }
@@ -198,7 +198,8 @@ where
         self.ts().state_indices()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         self.ts().state_color(state)
     }
 

--- a/automata/src/ts/operations/restricted.rs
+++ b/automata/src/ts/operations/restricted.rs
@@ -225,7 +225,8 @@ where
         })
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         self.ts().state_color(state)
     }
 }
@@ -239,7 +240,7 @@ impl<D: PredecessorIterable<EdgeColor = usize>> PredecessorIterable for ColorRes
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
         todo!()
     }
 }

--- a/automata/src/ts/operations/reverse.rs
+++ b/automata/src/ts/operations/reverse.rs
@@ -1,5 +1,8 @@
 use crate::{
-    ts::{predecessors::PredecessorIterable, transition_system::IsEdge},
+    ts::{
+        predecessors::PredecessorIterable,
+        transition_system::{Indexes, IsEdge},
+    },
     TransitionSystem,
 };
 
@@ -64,7 +67,8 @@ where
         Some(self.0.predecessors(state.to_index(self)?)?.map(Reversed))
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         self.0.state_color(state)
     }
 }
@@ -81,7 +85,7 @@ where
     where
         Self: 'this;
 
-    fn predecessors(&self, state: Self::StateIndex) -> Option<Self::EdgesToIter<'_>> {
-        Some(self.0.edges_from(state)?.map(Reversed))
+    fn predecessors<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::EdgesToIter<'_>> {
+        Some(self.0.edges_from(state.to_index(self)?)?.map(Reversed))
     }
 }

--- a/automata/src/ts/operations/subset.rs
+++ b/automata/src/ts/operations/subset.rs
@@ -142,7 +142,8 @@ impl<Ts: TransitionSystem> TransitionSystem for SubsetConstruction<Ts> {
         Some(DeterministicEdgesFrom::new(self, state.to_index(self)?))
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         let Some(color) = self.states.borrow().get(state).map(|q| {
             q.iter()
                 .map(|idx| {

--- a/automata/src/ts/quotient.rs
+++ b/automata/src/ts/quotient.rs
@@ -4,7 +4,10 @@ use itertools::Itertools;
 
 use crate::{Alphabet, Partition, Pointed, RightCongruence, Set, Show, TransitionSystem};
 
-use super::{transition_system::IsEdge, Deterministic, ExpressionOf, SymbolOf};
+use super::{
+    transition_system::{Indexes, IsEdge},
+    Deterministic, ExpressionOf, SymbolOf,
+};
 
 /// A quotient takes a transition system and merges states which are in the same
 /// congruence class of some [`Partition`]. We assume that the [`Partition`] is
@@ -205,7 +208,8 @@ impl<Ts: Deterministic> TransitionSystem for Quotient<Ts> {
         0..self.partition.len()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         let mut it = self.class_iter_by_id(state)?;
         it.map(|o| self.ts.state_color(o)).collect()
     }

--- a/automata/src/ts/sproutable.rs
+++ b/automata/src/ts/sproutable.rs
@@ -164,11 +164,14 @@ pub trait Sproutable: TransitionSystem {
     ) -> Self::ExtendStateIndexIter;
     /// Removes the state with the given index. Note, that this should also remove all transitions
     /// that start or end in the given state. If the no state with the given `index` exists, the
-    /// method is a no-op.
-    ///
-    fn set_state_color<X: Into<StateColor<Self>>>(&mut self, index: Self::StateIndex, color: X);
+    /// method may panic or simply print an error!
+    /// TODO: Decide on the behavior of this method for states that do not exist.
+    fn set_state_color<Idx: Indexes<Self>, X: Into<StateColor<Self>>>(
+        &mut self,
+        index: Idx,
+        color: X,
+    );
     /// Sets the state color of the initial state.
-    ///
     fn set_initial_color<X: Into<StateColor<Self>>>(&mut self, color: X)
     where
         Self: Pointed,

--- a/automata/src/ts/transition_system.rs
+++ b/automata/src/ts/transition_system.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, hash::Hash};
+use std::{any::Any, f32::consts::E, hash::Hash};
 
 use crate::{
     automaton::Initialized,
@@ -32,6 +32,7 @@ use super::{
     CanInduce, EdgeColor, HashTs, IndexType, Induced, Path, StateColor,
 };
 
+use hoars::State;
 use impl_tools::autoimpl;
 use itertools::Itertools;
 
@@ -198,12 +199,18 @@ pub trait TransitionSystem: Sized {
     /// Returns true if and only if there exists a transition from the given `source` state to the
     /// given `target` state, whose expression is matched by the given `sym`. If either the source
     /// or the target state does not exist, `false` is returned.
-    fn has_transition(
+    fn has_transition<Idx: Indexes<Self>, Jdx: Indexes<Self>>(
         &self,
-        source: Self::StateIndex,
+        source: Idx,
         sym: SymbolOf<Self>,
-        target: Self::StateIndex,
+        target: Jdx,
     ) -> bool {
+        let Some(source) = source.to_index(self) else {
+            return false;
+        };
+        let Some(target) = target.to_index(self) else {
+            return false;
+        };
         if let Some(mut it) = self.edges_from(source) {
             it.any(|t| t.target() == target && t.expression().matches(sym))
         } else {
@@ -243,18 +250,21 @@ pub trait TransitionSystem: Sized {
     }
 
     /// Returns the color of the given `state`, if it exists. Otherwise, `None` is returned.
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor>;
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor>;
 
     /// Attempts to find a word which leads from the state `from` to state `to`. If no such
     /// word exists, `None` is returned.
-    fn word_from_to(
+    fn word_from_to<Idx: Indexes<Self>, Jdx: Indexes<Self>>(
         &self,
-        from: Self::StateIndex,
-        to: Self::StateIndex,
+        from: Idx,
+        to: Jdx,
     ) -> Option<Vec<SymbolOf<Self>>>
     where
         Self: Sized,
     {
+        let from = from.to_index(self)?;
+        let to = to.to_index(self)?;
+
         self.minimal_representatives_from(from)
             .find_map(|(word, state)| if state == to { Some(word) } else { None })
     }
@@ -267,6 +277,12 @@ pub trait TransitionSystem: Sized {
     /// Returns `true` if and only if there exists at least one state.
     fn is_empty(&self) -> bool {
         self.size() == 0
+    }
+
+    /// Tries to return the index of the state identified by `state`. If the state does not exist,
+    /// `None` is returned.
+    fn find_state_index<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateIndex> {
+        state.to_index(self)
     }
 
     /// Returns true if and only if the given state `index` exists.
@@ -296,7 +312,7 @@ pub trait TransitionSystem: Sized {
 
     /// Obtains the [`Self::StateIndex`] of a state if it can be found. See [`Indexes`]
     /// for more.
-    fn get<I: Indexes<Self>>(&self, elem: I) -> Option<Self::StateIndex>
+    fn get<Idx: Indexes<Self>>(&self, elem: Idx) -> Option<Self::StateIndex>
     where
         Self: Sized,
     {
@@ -305,10 +321,13 @@ pub trait TransitionSystem: Sized {
 
     /// Returns a [`Initialized`] wrapper around `self`, which designates the given `initial` state.
     /// Note that this function does not (yet) ensure that the index actually exists!
-    fn with_initial(self, initial: Self::StateIndex) -> Initialized<Self>
+    fn with_initial<Idx: Indexes<Self>>(self, initial: Idx) -> Initialized<Self>
     where
         Self: Sized,
     {
+        let initial = initial
+            .to_index(&self)
+            .expect("Cannot set initial state that does not exist");
         assert!(
             self.contains_state_index(initial),
             "Cannot set initial state that does not exist"
@@ -438,18 +457,33 @@ pub trait TransitionSystem: Sized {
     }
 
     /// Returns `true` iff the given state is reachable from the initial state.
-    fn is_reachable(&self, state: Self::StateIndex) -> bool
+    fn is_reachable<Idx: Indexes<Self>>(&self, state: Idx) -> bool
     where
         Self: Sized + Pointed,
     {
+        let Some(state) = state.to_index(self) else {
+            return false;
+        };
         self.is_reachable_from(self.initial(), state)
     }
 
     /// Returns `true` iff the given `state` is reachable from the given `origin` state.
-    fn is_reachable_from(&self, origin: Self::StateIndex, state: Self::StateIndex) -> bool
+    fn is_reachable_from<Idx: Indexes<Self>, Jdx: Indexes<Self>>(
+        &self,
+        origin: Idx,
+        state: Jdx,
+    ) -> bool
     where
         Self: Sized + Pointed,
     {
+        let Some(origin) = origin.to_index(self) else {
+            tracing::error!("Origin state does not exist");
+            return false;
+        };
+        let Some(state) = state.to_index(self) else {
+            tracing::error!("Target state does not exist");
+            return false;
+        };
         self.reachable_state_indices_from(origin)
             .any(|s| s == state)
     }
@@ -482,14 +516,19 @@ pub trait TransitionSystem: Sized {
 
     /// Returns an iterator over the minimal representatives (i.e. length-lexicographically minimal
     /// word reaching the state) of each state that is reachable from the given `state`.
-    fn minimal_representatives_from<I: Into<Self::StateIndex>>(
+    fn minimal_representatives_from<Idx: Indexes<Self>>(
         &self,
-        state: I,
+        state: Idx,
     ) -> MinimalRepresentatives<&Self>
     where
         Self: Sized,
     {
-        MinimalRepresentatives::new(self, state.into())
+        MinimalRepresentatives::new(
+            self,
+            state
+                .to_index(self)
+                .expect("cannot comput minimal representatives from non-existing state"),
+        )
     }
 
     /// Returns an iterator over the indices of the states that are reachable from the initial state.
@@ -501,9 +540,9 @@ pub trait TransitionSystem: Sized {
     }
 
     /// Returns an iterator over the indices of the states that are reachable from the given `state`.
-    fn reachable_state_indices_from<I: Indexes<Self>>(
+    fn reachable_state_indices_from<Idx: Indexes<Self>>(
         &self,
-        state: I,
+        state: Idx,
     ) -> ReachableStateIndices<&Self>
     where
         Self: Sized,
@@ -515,7 +554,7 @@ pub trait TransitionSystem: Sized {
     }
 
     /// Returns an iterator over the states that are reachable from the given `state`.
-    fn reachable_states_from<I: Indexes<Self>>(&self, state: I) -> ReachableStates<&Self>
+    fn reachable_states_from<Idx: Indexes<Self>>(&self, state: Idx) -> ReachableStates<&Self>
     where
         Self: Sized,
     {
@@ -854,7 +893,8 @@ macro_rules! impl_ts_by_passthrough_on_wrapper {
                 self.ts().state_indices()
             }
 
-            fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+            fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+                let state = state.to_index(self)?;
                 self.ts().state_color(state)
             }
 
@@ -876,14 +916,6 @@ macro_rules! impl_ts_by_passthrough_on_wrapper {
                 symbol: SymbolOf<Self>,
             ) -> Option<Self::EdgeRef<'_>> {
                 self.ts().transition(state.to_index(self)?, symbol)
-            }
-
-            fn edge_color(
-                &self,
-                state: Self::StateIndex,
-                expression: &ExpressionOf<Self>,
-            ) -> Option<EdgeColor<Self>> {
-                self.ts().edge_color(state, expression)
             }
         }
     };
@@ -908,7 +940,8 @@ impl<Ts: TransitionSystem> TransitionSystem for &Ts {
         Ts::state_indices(self)
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         Ts::state_color(self, state)
     }
 
@@ -938,7 +971,8 @@ impl<Ts: TransitionSystem> TransitionSystem for &mut Ts {
         Ts::state_indices(self)
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         Ts::state_color(self, state)
     }
 
@@ -970,7 +1004,8 @@ impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for RightCongruence<A, Q,
         self.ts().state_indices()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         self.ts().state_color(state)
     }
 
@@ -982,15 +1017,15 @@ impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for RightCongruence<A, Q,
         Some(self.initial())
     }
 }
-impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone + Hash + Eq> TransitionSystem
-    for HashTs<A, Q, C, Idx>
+impl<A: Alphabet, IdxTy: IndexType, Q: Clone, C: Clone + Hash + Eq> TransitionSystem
+    for HashTs<A, Q, C, IdxTy>
 {
     type StateColor = Q;
     type EdgeColor = C;
-    type StateIndex = Idx;
-    type EdgeRef<'this> = EdgeReference<'this, A::Expression, Idx, C> where Self: 'this;
-    type EdgesFromIter<'this> = BTSEdgesFrom<'this, A::Expression, Idx, C> where Self: 'this;
-    type StateIndices<'this> = std::iter::Cloned<std::collections::hash_map::Keys<'this, Idx, super::index_ts::HashTsState<A, Q, C, Idx>>> where Self: 'this;
+    type StateIndex = IdxTy;
+    type EdgeRef<'this> = EdgeReference<'this, A::Expression, IdxTy, C> where Self: 'this;
+    type EdgesFromIter<'this> = BTSEdgesFrom<'this, A::Expression, IdxTy, C> where Self: 'this;
+    type StateIndices<'this> = std::iter::Cloned<std::collections::hash_map::Keys<'this, IdxTy, super::index_ts::HashTsState<A, Q, C, IdxTy>>> where Self: 'this;
 
     type Alphabet = A;
 
@@ -1001,8 +1036,9 @@ impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone + Hash + Eq> TransitionSyst
         self.states.keys().cloned()
     }
 
-    fn state_color(&self, index: Idx) -> Option<StateColor<Self>> {
-        self.raw_state_map().get(&index).map(|s| s.color().clone())
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
+        self.raw_state_map().get(&state).map(|s| s.color().clone())
     }
 
     fn edges_from<X: Indexes<Self>>(&self, state: X) -> Option<Self::EdgesFromIter<'_>> {
@@ -1065,7 +1101,8 @@ where
         ProductStatesIter::new(&self.0, &self.1)
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<Self::StateColor> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         let ProductIndex(l, r) = state;
         let left = self.0.state_color(l)?;
         let right = self.1.state_color(r)?;
@@ -1106,7 +1143,8 @@ where
         self.ts().state_indices()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         let color = self.ts().state_color(state)?;
         Some((self.f())(color))
     }
@@ -1144,7 +1182,8 @@ where
         self.ts().state_indices()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         self.ts().state_color(state)
     }
 
@@ -1180,7 +1219,8 @@ where
         self.ts().state_indices()
     }
 
-    fn state_color(&self, state: Self::StateIndex) -> Option<StateColor<Self>> {
+    fn state_color<Idx: Indexes<Self>>(&self, state: Idx) -> Option<Self::StateColor> {
+        let state = state.to_index(self)?;
         assert!((self.filter()).is_unmasked(state));
         self.ts().state_color(state)
     }


### PR DESCRIPTION
Many methods on `TransitionSystem`, `Determinstic` and `Sproutable` have been modified to take an `Indexes<Self>` instead of a `Self::StateIndex` which allows more types to be used in that place.

For example instead of only allowing `StateIndex`, we can now also use a finite word (at least for a pointed transition system) or a class of some right congruence.