### PR TITLE
Manage dependency automata

### DIFF
--- a/automata-learning/Cargo.toml
+++ b/automata-learning/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 tracing = "0.1"
 tracing-subscriber = "0.3"
-automata = { git = "https://github.com/leonbohn/automata" }
+automata = { git = "https://github.com/leonbohn/automata", rev = "7264bb8"}
 itertools = "0.12"
 impl-tools = "0.10.0"
 tabled = { version = "0.15.0", features = ["ansi"] }

--- a/automata-learning/src/active/oracle.rs
+++ b/automata-learning/src/active/oracle.rs
@@ -1,4 +1,4 @@
-use automata::{prelude::*, ts::operations::MapStateColor, word::LinearWord};
+use automata::{prelude::*, transition_system::operations::MapStateColor, word::LinearWord};
 
 use crate::passive::Sample;
 
@@ -309,7 +309,7 @@ where
 #[cfg(test)]
 mod tests {
     use automata::{
-        ts::{Dottable, NTS},
+        transition_system::{Dottable, NTS},
         TransitionSystem,
     };
 

--- a/automata-learning/src/passive/mod.rs
+++ b/automata-learning/src/passive/mod.rs
@@ -1,7 +1,7 @@
 use automata::{
     congruence::ColoredClass,
     prelude::*,
-    ts::{operations::MapStateColor, IndexedAlphabet},
+    transition_system::{operations::MapStateColor, IndexedAlphabet},
 };
 use owo_colors::OwoColorize;
 use tracing::{debug, trace};

--- a/automata-learning/src/passive/precise.rs
+++ b/automata-learning/src/passive/precise.rs
@@ -4,11 +4,11 @@ use automata::{
     automaton::{DPALike, MealyLike, MooreLike, DPA},
     congruence::ColoredClass,
     prelude::{Expression, IsEdge, DFA},
-    ts::{
+    transition_system::{
         dot::{DotStateAttribute, DotTransitionAttribute},
         reachable::ReachableStateIndices,
-        transition_system::Indexes,
-        Deterministic, Dottable, EdgeColor, ExpressionOf, IndexType, Sproutable, StateColor,
+        Deterministic, Dottable, EdgeColor, ExpressionOf, IndexType, Indexes, Sproutable,
+        StateColor,
     },
     Alphabet, Map, Pointed, RightCongruence, Show, TransitionSystem, Void,
 };
@@ -495,7 +495,7 @@ impl<A: Alphabet, const N: usize> Dottable for PreciseDPA<A, N> {
     fn dot_state_attributes(
         &self,
         idx: Self::StateIndex,
-    ) -> impl IntoIterator<Item = automata::ts::dot::DotStateAttribute>
+    ) -> impl IntoIterator<Item = automata::transition_system::dot::DotStateAttribute>
     where
         (String, StateColor<Self>): Show,
     {
@@ -508,7 +508,7 @@ impl<A: Alphabet, const N: usize> Dottable for PreciseDPA<A, N> {
     fn dot_transition_attributes<'a>(
         &'a self,
         t: Self::EdgeRef<'a>,
-    ) -> impl IntoIterator<Item = automata::ts::dot::DotTransitionAttribute>
+    ) -> impl IntoIterator<Item = automata::transition_system::dot::DotTransitionAttribute>
     where
         (&'a ExpressionOf<Self>, EdgeColor<Self>): Show,
     {

--- a/automata-learning/src/passive/sample/canonic_coloring.rs
+++ b/automata-learning/src/passive/sample/canonic_coloring.rs
@@ -15,7 +15,7 @@ impl<A: Alphabet> ClassifiesIdempotents<A> for PeriodicOmegaSample<A> {
 
 #[cfg(test)]
 mod tests {
-    use automata::{ts::Dottable, RightCongruence, TransitionSystem};
+    use automata::{transition_system::Dottable, RightCongruence, TransitionSystem};
 
     use crate::{passive::sprout::tests::testing_larger_forc_sample, AnnotatedCongruence};
 

--- a/automata-learning/src/passive/sample/characterize.rs
+++ b/automata-learning/src/passive/sample/characterize.rs
@@ -10,7 +10,7 @@ use std::{
 use automata::{
     automaton::{IntoDPA, OmegaAcceptanceCondition},
     prelude::*,
-    ts::{reachable::ReachableStateIndices, Quotient},
+    transition_system::{operations::Quotient, reachable::ReachableStateIndices},
     word::Concat,
     Map, Set,
 };
@@ -390,7 +390,7 @@ mod tests {
 
     use automata::{
         automaton::{DPALike, MealyLike, MooreLike, DPA},
-        ts::{Deterministic, Dottable, NTS},
+        transition_system::{Deterministic, Dottable, NTS},
         TransitionSystem,
     };
 

--- a/automata-learning/src/passive/sample/split.rs
+++ b/automata-learning/src/passive/sample/split.rs
@@ -1,5 +1,5 @@
 use automata::{
-    congruence::FORC, ts::transition_system::Indexes, Alphabet, Class, Color, Map, RightCongruence,
+    congruence::FORC, transition_system::Indexes, Alphabet, Class, Color, Map, RightCongruence,
     TransitionSystem,
 };
 use itertools::Itertools;

--- a/automata-learning/src/passive/sprout.rs
+++ b/automata-learning/src/passive/sprout.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::Display,
 };
 
-use automata::{prelude::*, ts::operations::ProductIndex, Map, Set};
+use automata::{prelude::*, transition_system::operations::ProductIndex, Map, Set};
 use itertools::Itertools;
 use tracing::trace;
 
@@ -391,7 +391,7 @@ pub(crate) mod tests {
         alphabet::CharAlphabet,
         congruence::FORC,
         prelude::*,
-        ts::{Dottable, Sproutable},
+        transition_system::{Dottable, Sproutable},
         Class, Pointed, RightCongruence, TransitionSystem,
     };
     use itertools::Itertools;

--- a/automata-learning/src/prefixtree.rs
+++ b/automata-learning/src/prefixtree.rs
@@ -1,7 +1,8 @@
 use std::collections::VecDeque;
 
 use automata::{
-    ts::Sproutable, word::OmegaWord, Alphabet, Map, Pointed, RightCongruence, Set, Void,
+    transition_system::Sproutable, word::OmegaWord, Alphabet, Map, Pointed, RightCongruence, Set,
+    Void,
 };
 use itertools::Itertools;
 use tracing::trace;
@@ -82,7 +83,7 @@ pub fn prefix_tree<A: Alphabet, W: Into<ReducedOmegaWord<A::Symbol>>, I: IntoIte
 mod tests {
     use automata::{
         alphabet::CharAlphabet,
-        ts::{Deterministic, Dottable, Sproutable},
+        transition_system::{Deterministic, Dottable, Sproutable},
         upw,
         word::PeriodicOmegaWord,
         TransitionSystem, Void,

--- a/automata-learning/src/priority_mapping.rs
+++ b/automata-learning/src/priority_mapping.rs
@@ -6,8 +6,9 @@ use owo_colors::OwoColorize;
 use automata::{
     automaton::MooreLike,
     congruence::ColoredClass,
+    dag::Dag,
     prelude::*,
-    ts::dot::{DotStateAttribute, Dottable},
+    transition_system::dot::{DotStateAttribute, Dottable},
     Set,
 };
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.78"
-automata = { git = "https://github.com/leonbohn/automata" }
+automata = { git = "https://github.com/leonbohn/automata", rev = "7264bb8" }
 automata-learning = { version = "0.1", path = "../automata-learning" }
 clap = { version = "4.4", features = ["cargo"] }
 tracing = "0.1"

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,4 +1,4 @@
-use automata::{congruence::FORC, ts::dot::display_dot, Map, TransitionSystem};
+use automata::{congruence::FORC, transition_system::dot::display_dot, Map, TransitionSystem};
 use automata_learning::passive::{
     sprout::{iteration_consistency_conflicts, prefix_consistency_conflicts, sprout},
     OmegaSample,


### PR DESCRIPTION
I fixed the version of the automata crate to a specific commit (the most recent one when writing this). This makes updating to a newer version of the crate a bit more complicated but it ensures that everyone working with the main branch of this repository also uses the same version of the automata crate.

Further, I also adjusted some `use` statements such that the version specified in the commit works.